### PR TITLE
Extended 'mix' type functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ Any methods that may be useful.
 
 `api.mix_system_status(mix_id, plant_id)` Get instantaneous values for Mix system e.g. current import/export, generation, charging rates etc.
 
+`api.mix_detail(mix_id, plant_id, timespan=<0=hour, 1=day, 2=month>, date)` Get detailed values for a timespan, also includes some additional values calculated from the graphs as the backend metrics seem inconsistent
+
 `api.storage_detail(storage_id)` Get detailed data on storage (battery).
 
 `api.storage_params(storage_id)` Get a ton of info on storage (More info, more convoluted).

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ Any methods that may be useful.
 
 `api.mix_detail(mix_id, plant_id, timespan=<0=hour, 1=day, 2=month>, date)` Get detailed values for a timespan, the API call also returns totals data for the same values in this time window
 
+`api.dashboard_data(plant_id, timespan=<0=hour, 1=day, 2=month>, date)` Get dashboard values for a timespan, the API call also returns totals data for the same values in this time window. NOTE: Many of the values on this API call are incorrect for 'Mix' systems, however it still provides some accurate values that are unavailable on other API calls.
+
 `api.storage_detail(storage_id)` Get detailed data on storage (battery).
 
 `api.storage_params(storage_id)` Get a ton of info on storage (More info, more convoluted).

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Any methods that may be useful.
 
 `api.mix_system_status(mix_id, plant_id)` Get instantaneous values for Mix system e.g. current import/export, generation, charging rates etc.
 
-`api.mix_detail(mix_id, plant_id, timespan=<0=hour, 1=day, 2=month>, date)` Get detailed values for a timespan, also includes some additional values calculated from the graphs as the backend metrics seem inconsistent
+`api.mix_detail(mix_id, plant_id, timespan=<0=hour, 1=day, 2=month>, date)` Get detailed values for a timespan, the API call also returns totals data for the same values in this time window
 
 `api.storage_detail(storage_id)` Get detailed data on storage (battery).
 

--- a/README.md
+++ b/README.md
@@ -36,11 +36,11 @@ Any methods that may be useful.
 
 `api.tlx_detail(tlx_id)` Get detailed data on a tlx type inverter.
 
-`api.mix_info(plant_id, mix_id)` Get high level information about the Mix system including daily and overall totals
+`api.mix_info(mix_id, plant_id=None)` Get high level information about the Mix system including daily and overall totals. NOTE: plant_id is an optional parameter, it does not appear to be used by the remote API, but is used by the mobile app these calls were reverse-engineered from.
 
-`api.mix_totals(plant_id, mix_id)` Get daily and overall total information for the Mix system (duplicates some of the information from `mix_info`
+`api.mix_totals(mix_id, plant_id)` Get daily and overall total information for the Mix system (duplicates some of the information from `mix_info`
 
-`api.mix_system_status(plant_id, mix_id)` Get instantaneous values for Mix system e.g. current import/export, generation, charging rates etc.
+`api.mix_system_status(mix_id, plant_id)` Get instantaneous values for Mix system e.g. current import/export, generation, charging rates etc.
 
 `api.storage_detail(storage_id)` Get detailed data on storage (battery).
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ Any methods that may be useful.
 
 `api.tlx_detail(tlx_id)` Get detailed data on a tlx type inverter.
 
+`api.mix_info(plant_id, mix_id)` Get high level information about the Mix system including daily and overall totals
+
+`api.mix_totals(plant_id, mix_id)` Get daily and overall total information for the Mix system (duplicates some of the information from `mix_info`
+
+`api.mix_system_status(plant_id, mix_id)` Get instantaneous values for Mix system e.g. current import/export, generation, charging rates etc.
+
 `api.storage_detail(storage_id)` Get detailed data on storage (battery).
 
 `api.storage_params(storage_id)` Get a ton of info on storage (More info, more convoluted).

--- a/growattServer/__init__.py
+++ b/growattServer/__init__.py
@@ -144,40 +144,50 @@ class GrowattApi:
         data = json.loads(response.content.decode('utf-8'))
         return data
 
-    def mix_info(self, plant_id, mix_id):
+    def mix_info(self, mix_id, plant_id = None):
         """
         Get high level values from Mix device.
+        mix_id: The serial number (device_sn) of the inverter
+        plant_id: Optional - The ID of the plant (the mobile app uses this but it does not appear to be necessary)
         """
-        response = self.session.get(self.get_url('newMixApi.do'), params={
+        request_params={
             'op': 'getMixInfo',
-            'plantId': plant_id,
             'mixId': mix_id
-        })
+        }
+
+        if (plant_id):
+          request_params['plantId'] = plant_id
+
+        response = self.session.get(self.get_url('newMixApi.do'), params=request_params)
 
         data = json.loads(response.content.decode('utf-8'))
         return data['obj']
 
-    def mix_totals(self, plant_id, mix_id):
+    def mix_totals(self, mix_id, plant_id):
         """
         Get "Totals" from Mix device.
+        mix_id: The serial number (device_sn) of the inverter
+        plant_id: The ID of the plant
         """
         response = self.session.post(self.get_url('newMixApi.do'), params={
             'op': 'getEnergyOverview',
-            'plantId': plant_id,
-            'mixId': mix_id
+            'mixId': mix_id,
+            'plantId': plant_id
         })
 
         data = json.loads(response.content.decode('utf-8'))
         return data['obj']
 
-    def mix_system_status(self, plant_id, mix_id):
+    def mix_system_status(self, mix_id, plant_id):
         """
         Get "Status" from Mix device.
+        mix_id: The serial number (device_sn) of the inverter
+        plant_id: The ID of the plant
         """
         response = self.session.post(self.get_url('newMixApi.do'), params={
             'op': 'getSystemStatus_KW',
-            'plantId': plant_id,
-            'mixId': mix_id
+            'mixId': mix_id,
+            'plantId': plant_id
         })
 
         data = json.loads(response.content.decode('utf-8'))

--- a/growattServer/__init__.py
+++ b/growattServer/__init__.py
@@ -327,35 +327,6 @@ class GrowattApi:
         })
         data = json.loads(response.content.decode('utf-8'))
 
-        #Some of the 'totals' values that are returned by this function do not align to what we would expect, however the graph data always seems to be accurate.
-        #Therefore, here we take a moment to calculate the same values provided elsewhere but based on the graph data instead
-        #The particular stats that we question are 'load consumption' (elocalLoad)  and 'import from grid' (etouser) which seem to be calculated from one-another
-        #It would appear that 'etouser' is calculated on the backend incorrectly for systems that use AC battery charged (e.g. during cheap nighttime rates)
-        if timespan == Timespan.hour or timespan == Timespan.day:
-          pacToGridToday = 0.0
-          pacToUserToday = 0.0
-          pdischargeToday = 0.0
-          ppvToday = 0.0
-          sysOutToday = 0.0
-
-          chartData = data['obj']['chartData']
-          for time_entry in chartData:
-            #For each time entry convert it's wattage into kWh, this assumes that the wattage value is
-            #the same for the whole 5 minute window (it's the only assumption we can make)
-            #We Multiply the wattage by 5/60 (the number of minutes of the time window divided by the number of minutes in an hour)
-            #to give us the equivalent kWh reading for that 5 minute window
-            pacToGridToday += float(chartData[time_entry]['pacToGrid']) * (5/60)
-            pacToUserToday += float(chartData[time_entry]['pacToUser']) * (5/60)
-            pdischargeToday += float(chartData[time_entry]['pdischarge']) * (5/60)
-            ppvToday += float(chartData[time_entry]['ppv']) * (5/60)
-            sysOutToday += float(chartData[time_entry]['sysOut']) * (5/60)
-
-          data['obj']['calculatedPacToGridTodayKwh'] = round(pacToGridToday,2)
-          data['obj']['calculatedPacToUserTodayKwh'] = round(pacToUserToday,2)
-          data['obj']['calculatedPdischargeTodayKwh'] = round(pdischargeToday,2)
-          data['obj']['calculatedPpvTodayKwh'] = round(ppvToday,2)
-          data['obj']['calculatedSysOutTodayKwh'] = round(sysOutToday,2)
-
         return data['obj']
 
     def storage_detail(self, storage_id):

--- a/growattServer/__init__.py
+++ b/growattServer/__init__.py
@@ -144,17 +144,44 @@ class GrowattApi:
         data = json.loads(response.content.decode('utf-8'))
         return data
 
-    def mix_info(self, mix_id):
+    def mix_info(self, plant_id, mix_id):
         """
-        Get "All parameters" from Mix device.
+        Get high level values from Mix device.
         """
         response = self.session.get(self.get_url('newMixApi.do'), params={
             'op': 'getMixInfo',
+            'plantId': plant_id,
             'mixId': mix_id
         })
 
         data = json.loads(response.content.decode('utf-8'))
-        return data
+        return data['obj']
+
+    def mix_totals(self, plant_id, mix_id):
+        """
+        Get "Totals" from Mix device.
+        """
+        response = self.session.post(self.get_url('newMixApi.do'), params={
+            'op': 'getEnergyOverview',
+            'plantId': plant_id,
+            'mixId': mix_id
+        })
+
+        data = json.loads(response.content.decode('utf-8'))
+        return data['obj']
+
+    def mix_system_status(self, plant_id, mix_id):
+        """
+        Get "Status" from Mix device.
+        """
+        response = self.session.post(self.get_url('newMixApi.do'), params={
+            'op': 'getSystemStatus_KW',
+            'plantId': plant_id,
+            'mixId': mix_id
+        })
+
+        data = json.loads(response.content.decode('utf-8'))
+        return data['obj']
 
     def storage_detail(self, storage_id):
         """

--- a/growattServer/__init__.py
+++ b/growattServer/__init__.py
@@ -23,7 +23,7 @@ class Timespan(IntEnum):
 
 
 class GrowattApi:
-    server_url = 'http://server.growatt.com/'
+    server_url = 'https://server.growatt.com/'
 
     def __init__(self):
         self.session = requests.Session()

--- a/growattServer/__init__.py
+++ b/growattServer/__init__.py
@@ -231,7 +231,7 @@ class GrowattApi:
         Returns:
         'SOC' -- Statement of charge (remaining battery %)
         'chargePower' -- Battery charging rate in kw
-        'fAc' -- ??? 50
+        'fAc' -- Frequency (Hz)
         'lost' -- System status e.g. 'mix.status.normal'
         'pLocalLoad' -- Load conumption in kW
         'pPv1' -- PV1 Wattage in W
@@ -326,6 +326,36 @@ class GrowattApi:
             'date': date_str
         })
         data = json.loads(response.content.decode('utf-8'))
+
+        #Some of the 'totals' values that are returned by this function do not align to what we would expect, however the graph data always seems to be accurate.
+        #Therefore, here we take a moment to calculate the same values provided elsewhere but based on the graph data instead
+        #The particular stats that we question are 'load consumption' (elocalLoad)  and 'import from grid' (etouser) which seem to be calculated from one-another
+        #It would appear that 'etouser' is calculated on the backend incorrectly for systems that use AC battery charged (e.g. during cheap nighttime rates)
+        if timespan == Timespan.hour or timespan == Timespan.day:
+          pacToGridToday = 0.0
+          pacToUserToday = 0.0
+          pdischargeToday = 0.0
+          ppvToday = 0.0
+          sysOutToday = 0.0
+
+          chartData = data['obj']['chartData']
+          for time_entry in chartData:
+            #For each time entry convert it's wattage into kWh, this assumes that the wattage value is
+            #the same for the whole 5 minute window (it's the only assumption we can make)
+            #We Multiply the wattage by 5/60 (the number of minutes of the time window divided by the number of minutes in an hour)
+            #to give us the equivalent kWh reading for that 5 minute window
+            pacToGridToday += float(chartData[time_entry]['pacToGrid']) * (5/60)
+            pacToUserToday += float(chartData[time_entry]['pacToUser']) * (5/60)
+            pdischargeToday += float(chartData[time_entry]['pdischarge']) * (5/60)
+            ppvToday += float(chartData[time_entry]['ppv']) * (5/60)
+            sysOutToday += float(chartData[time_entry]['sysOut']) * (5/60)
+
+          data['obj']['calculatedPacToGridTodayKwh'] = round(pacToGridToday,2)
+          data['obj']['calculatedPacToUserTodayKwh'] = round(pacToUserToday,2)
+          data['obj']['calculatedPdischargeTodayKwh'] = round(pdischargeToday,2)
+          data['obj']['calculatedPpvTodayKwh'] = round(ppvToday,2)
+          data['obj']['calculatedSysOutTodayKwh'] = round(sysOutToday,2)
+
         return data['obj']
 
     def storage_detail(self, storage_id):

--- a/mix_example.py
+++ b/mix_example.py
@@ -74,9 +74,9 @@ for plant in plant_list['data']:
     #NOTE - This is the bit where we specifically only handle information on Mix devices - this won't work for non-mix devices
 
     #These two API calls return lots of duplicated information, but each also holds unique information as well
-    mix_info = api.mix_info(plant_id, device_sn)
+    mix_info = api.mix_info(device_sn, plant_id)
     #pp.pprint(mix_info)
-    mix_totals = api.mix_totals(plant_id, device_sn)
+    mix_totals = api.mix_totals(device_sn, plant_id)
     #pp.pprint(mix_totals)
     indent_print("*TOTAL VALUES*", 4)
     indent_print("==Today Totals==", 4)
@@ -94,7 +94,7 @@ for plant in plant_list['data']:
     print("")
 
     #This call gets all of the instantaneous values from the system e.g. current load, generation etc.
-    mix_status = api.mix_system_status(plant_id, device_sn)
+    mix_status = api.mix_system_status(device_sn, plant_id)
     #pp.pprint(mix_status)
     #NOTE - There are some other values available in mix_status, however these are the most useful ones
     indent_print("*CURRENT VALUES*",4)

--- a/mix_example.py
+++ b/mix_example.py
@@ -75,7 +75,7 @@ for plant in plant_list['data']:
 
     #These two API calls return lots of duplicated information, but each also holds unique information as well
     mix_info = api.mix_info(device_sn, plant_id)
-    #pp.pprint(mix_info)
+    pp.pprint(mix_info)
     mix_totals = api.mix_totals(device_sn, plant_id)
     #pp.pprint(mix_totals)
     indent_print("*TOTAL VALUES*", 4)
@@ -128,8 +128,10 @@ for plant in plant_list['data']:
     #pp.pprint(mix_detail)
 
     indent_print("*TODAY TOTALS BREAKDOWN*", 4)
+    indent_print("Self generation total (batteries & solar - from API) (kwh): %s:"%(mix_detail['eCharge']),6)
     indent_print("Load consumed from solar (kwh): %s"%(mix_detail['eChargeToday']),6)
     indent_print("Load consumed from batteries (kwh): %s"%(mix_detail['echarge1']),6)
+    indent_print("Self consumption total (batteries & solar - from API) (kwh): %s"%(mix_detail['eChargeToday1']),6)
     indent_print("Load consumed from grid (kwh): %s"%(mix_detail['etouser']),6)
     calculated_consumption = float(mix_detail['eChargeToday']) + float(mix_detail['echarge1']) + float(mix_detail['etouser'])
     indent_print("Load consumption (calculated) (kwh): %s"%(round(calculated_consumption,2)),6)

--- a/mix_example.py
+++ b/mix_example.py
@@ -1,0 +1,119 @@
+import growattServer
+import datetime
+import getpass
+import pprint
+
+"""
+This is a very trivial script that logs into a user's account and prints out useful data for a "Mix" system (Hybrid).
+The first half of the logic is applicable to all types of system. There is a clear point (marked in the script) where we specifically
+make calls to the "mix" WebAPI calls, at this point other types of systems will no longer work.
+This has been tested against my personal system (muppet3000) which is a hybrid inverter system.
+
+Throughout the script there are points where 'pp.pprint' has been commented out. If you wish to see all the data that is returned from those
+specific library calls, just uncomment them and they will appear as part of the output.
+
+NOTE - For some reason (not sure if this is just specific to my system or not) the "export to grid" daily total and overall total values don't seem to be populating. As such they are untested.
+This has been causing problems on my WebUI and mobile app too, it is not a bug in this library, the output from this script has been updated to reflect it's inaccuracy.
+"""
+
+pp = pprint.PrettyPrinter(indent=4)
+
+"""
+A really hacky function to allow me to print out things with an indent in-front
+"""
+def indent_print(to_output, indent):
+  indent_string = ""
+  for x in range(indent):
+    indent_string += " "
+  print(indent_string + to_output)
+
+#Prompt user for username
+username=input("Enter username:")
+
+#Prompt user to input password
+user_pass=getpass.getpass("Enter password:")
+
+api = growattServer.GrowattApi()
+login_response = api.login(username, user_pass)
+
+plant_list = api.plant_list(login_response['userId'])
+#pp.pprint(plant_list)
+
+print("***Totals for all plants***")
+pp.pprint(plant_list['totalData'])
+print("")
+
+print("***List of plants***")
+for plant in plant_list['data']:
+  indent_print("ID: %s, Name: %s"%(plant['plantId'], plant['plantName']), 2)
+print("")
+
+for plant in plant_list['data']:
+  plant_id = plant['plantId']
+  plant_name = plant['plantName']
+  plant_info=api.plant_info(plant_id)
+  #pp.pprint(plant_info)
+  print("***Info for Plant %s - %s***"%(plant_id, plant_name))
+  #There are more values in plant_info, but these are some of the useful/interesting ones
+  indent_print("CO2 Reducion: %s"%(plant_info['Co2Reduction']),2)
+  indent_print("Nominal Power (w): %s"%(plant_info['nominal_Power']),2)
+  indent_print("Solar Energy Today (kw): %s"%(plant_info['todayEnergy']),2)
+  indent_print("Solar Energy Total (kw): %s"%(plant_info['totalEnergy']),2)
+  print("")
+  indent_print("Devices in plant:",2)
+  for device in plant_info['deviceList']:
+    device_sn = device['deviceSn']
+    device_type = device['deviceType']
+    indent_print("- Device - SN: %s, Type: %s"%(device_sn, device_type),4)
+
+  print("")
+  for device in plant_info['deviceList']:
+    device_sn = device['deviceSn']
+    device_type = device['deviceType']
+    indent_print("**Device - SN: %s, Type: %s**"%(device_sn, device_type),2)
+    #NOTE - This is the bit where we specifically only handle information on Mix devices - this won't work for non-mix devices
+
+    #These two API calls return lots of duplicated information, but each also holds unique information as well
+    mix_info = api.mix_info(plant_id, device_sn)
+    #pp.pprint(mix_info)
+    mix_totals = api.mix_totals(plant_id, device_sn)
+    #pp.pprint(mix_totals)
+    indent_print("*TOTAL VALUES*", 4)
+    indent_print("==Today Totals==", 4)
+    indent_print("Battery Charge (kwh): %s"%(mix_info['eBatChargeToday']),6)
+    indent_print("Battery Discharge (kwh): %s"%(mix_info['eBatDisChargeToday']),6)
+    indent_print("Solar Generation (kwh): %s"%(mix_info['epvToday']),6)
+    indent_print("Local Load (kwh): %s"%(mix_totals['elocalLoadToday']),6)
+    indent_print("Export to Grid (kwh) (DOESN'T SEEM TO POPULATE ON MY SYSTEM): %s"%(mix_totals['etoGridToday']),6)
+    indent_print("==Overall Totals==",4)
+    indent_print("Battery Charge: %s"%(mix_info['eBatChargeTotal']),6)
+    indent_print("Battery Discharge (kwh): %s"%(mix_info['eBatDisChargeTotal']),6)
+    indent_print("Solar Generation (kwh): %s"%(mix_info['epvTotal']),6)
+    indent_print("Local Load (kwh): %s"%(mix_totals['elocalLoadTotal']),6)
+    indent_print("Export to Grid (kwh) (DOESN'T SEEM TO POPULATE ON MY SYSTEM): %s"%(mix_totals['etogridTotal']),6)
+    print("")
+
+    #This call gets all of the instantaneous values from the system e.g. current load, generation etc.
+    mix_status = api.mix_system_status(plant_id, device_sn)
+    #pp.pprint(mix_status)
+    #NOTE - There are some other values available in mix_status, however these are the most useful ones
+    indent_print("*CURRENT VALUES*",4)
+    indent_print("==Batteries==",4)
+    indent_print("Charging Batteries at (kw): %s"%(mix_status['chargePower']),6)
+    indent_print("Discharging Batteries at (kw): %s"%(mix_status['pdisCharge1']),6)
+    indent_print("Batteries %%: %s"%(mix_status['SOC']),6)
+
+    indent_print("==PVs==",4)
+    indent_print("PV1 wattage: %s"%(mix_status['pPv1']),6)
+    indent_print("PV2 wattage: %s"%(mix_status['pPv2']),6)
+    calc_pv_total = (float(mix_status['pPv1']) + float(mix_status['pPv2']))/1000
+    indent_print("PV total wattage (calculated) - KW: %s"%(round(calc_pv_total,2)),6)
+    indent_print("PV total wattage (API) - KW: %s"%(mix_status['ppv']),6)
+
+    indent_print("==Consumption==",4)
+    indent_print("Local load/consumption - KW: %s"%(mix_status['pLocalLoad']),6)
+
+    indent_print("==Import/Export==",4)
+    indent_print("Importing from Grid - KW: %s"%(mix_status['pactouser']),6)
+    indent_print("Exporting to Grid - KW: %s"%(mix_status['pactogrid']),6)
+

--- a/mix_example.py
+++ b/mix_example.py
@@ -127,12 +127,16 @@ for plant in plant_list['data']:
     #Option to print mix_detail again now we've made the additions
     #pp.pprint(mix_detail)
 
+    dashboard_data = api.dashboard_data(plant_id)
+    #pp.pprint(dashboard_data)
+
     indent_print("*TODAY TOTALS BREAKDOWN*", 4)
-    indent_print("Self generation total (batteries & solar - from API) (kwh): %s:"%(mix_detail['eCharge']),6)
+    indent_print("Self generation total (batteries & solar - from API) (kwh): %s"%(mix_detail['eCharge']),6)
     indent_print("Load consumed from solar (kwh): %s"%(mix_detail['eChargeToday']),6)
     indent_print("Load consumed from batteries (kwh): %s"%(mix_detail['echarge1']),6)
     indent_print("Self consumption total (batteries & solar - from API) (kwh): %s"%(mix_detail['eChargeToday1']),6)
     indent_print("Load consumed from grid (kwh): %s"%(mix_detail['etouser']),6)
+    indent_print("Total imported from grid (Load + AC charging) (kwh): %s"%(dashboard_data['etouser'].replace('kWh','')),6)
     calculated_consumption = float(mix_detail['eChargeToday']) + float(mix_detail['echarge1']) + float(mix_detail['etouser'])
     indent_print("Load consumption (calculated) (kwh): %s"%(round(calculated_consumption,2)),6)
     indent_print("Load consumption (API) (kwh): %s"%(mix_detail['elocalLoad']),6)
@@ -153,8 +157,8 @@ for plant in plant_list['data']:
     indent_print("mix_detail['calculatedPacToGridTodayKwh']: %s"%(mix_detail['calculatedPacToGridTodayKwh']), 8)
     print("")
 
-    indent_print("Imported from Grid (kwh) - NOT TRUSTED:", 6)
-    indent_print("mix_detail['etouser']: %s"%(mix_detail['etouser']), 8)
+    indent_print("Imported from Grid (kwh) - TRUSTED:", 6)
+    indent_print("dashboard_data['etouser']: %s"%(dashboard_data['etouser'].replace('kWh','')), 8)
     indent_print("mix_detail['calculatedPacToUserTodayKwh']: %s"%(mix_detail['calculatedPacToUserTodayKwh']), 8)
     print("")
 
@@ -171,7 +175,7 @@ for plant in plant_list['data']:
     indent_print("mix_detail['calculatedPpvTodayKwh']: %s"%(mix_detail['calculatedPpvTodayKwh']), 8)
     print("")
 
-    indent_print("Load Consumption (kwh) - NOT TRUSTED:", 6)
+    indent_print("Load Consumption (kwh) - TRUSTED:", 6)
     indent_print("mix_totals['elocalLoadToday']: %s"%(mix_totals['elocalLoadToday'],), 8)
     indent_print("mix_detail['elocalLoad']: %s"%(mix_detail['elocalLoad']), 8)
     indent_print("mix_detail['calculatedSysOutTodayKwh']: %s"%(mix_detail['calculatedSysOutTodayKwh']), 8)

--- a/mix_example.py
+++ b/mix_example.py
@@ -84,13 +84,31 @@ for plant in plant_list['data']:
     indent_print("Battery Discharge (kwh): %s"%(mix_info['eBatDisChargeToday']),6)
     indent_print("Solar Generation (kwh): %s"%(mix_info['epvToday']),6)
     indent_print("Local Load (kwh): %s"%(mix_totals['elocalLoadToday']),6)
-    indent_print("Export to Grid (kwh) (DOESN'T SEEM TO POPULATE ON MY SYSTEM): %s"%(mix_totals['etoGridToday']),6)
+    indent_print("Export to Grid (kwh): %s"%(mix_totals['etoGridToday']),6)
     indent_print("==Overall Totals==",4)
     indent_print("Battery Charge: %s"%(mix_info['eBatChargeTotal']),6)
     indent_print("Battery Discharge (kwh): %s"%(mix_info['eBatDisChargeTotal']),6)
     indent_print("Solar Generation (kwh): %s"%(mix_info['epvTotal']),6)
     indent_print("Local Load (kwh): %s"%(mix_totals['elocalLoadTotal']),6)
-    indent_print("Export to Grid (kwh) (DOESN'T SEEM TO POPULATE ON MY SYSTEM): %s"%(mix_totals['etogridTotal']),6)
+    indent_print("Export to Grid (kwh): %s"%(mix_totals['etogridTotal']),6)
+    print("")
+
+    mix_detail = api.mix_detail(device_sn, plant_id)
+    #pp.pprint(mix_detail)
+    indent_print("*TODAY TOTALS BREAKDOWN*", 4)
+    indent_print("Load consumed from solar (kwh): %s"%(mix_detail['eChargeToday']),6)
+    indent_print("Load consumed from batteries (kwh): %s"%(mix_detail['echarge1']),6)
+    indent_print("Load consumed from grid (kwh): %s"%(mix_detail['etouser']),6)
+    calculated_consumption = float(mix_detail['eChargeToday']) + float(mix_detail['echarge1']) + float(mix_detail['etouser'])
+    indent_print("Load consumption (calculated) (kwh): %s"%(round(calculated_consumption,2)),6)
+    indent_print("Load consumption (API) (kwh): %s"%(mix_detail['elocalLoad']),6)
+
+    indent_print("Exported (kwh): %s"%(mix_detail['eAcCharge']), 6)
+
+    solar_to_battery = round(float(mix_info['epvToday']) - float(mix_detail['eAcCharge']) - float(mix_detail['eChargeToday']),2)
+    indent_print("Solar battery charge (calculated) (kwh): %s"%(solar_to_battery), 6)
+    ac_to_battery = round(float(mix_info['eBatChargeToday']) - solar_to_battery,2)
+    indent_print("AC battery charge (calculated) (kwh): %s"%(ac_to_battery), 6)
     print("")
 
     #This call gets all of the instantaneous values from the system e.g. current load, generation etc.

--- a/mix_example.py
+++ b/mix_example.py
@@ -111,6 +111,39 @@ for plant in plant_list['data']:
     indent_print("AC battery charge (calculated) (kwh): %s"%(ac_to_battery), 6)
     print("")
 
+    indent_print("*TODAY TOTALS COMPARISONS*", 4)
+
+    indent_print("Export to Grid (kwh) - TRUSTED:", 6)
+    indent_print("mix_totals['etoGridToday']: %s"%(mix_totals['etoGridToday']), 8)
+    indent_print("mix_detail['eAcCharge']: %s"%(mix_detail['eAcCharge']), 8)
+    indent_print("mix_detail['calculatedPacToGridTodayKwh']: %s"%(mix_detail['calculatedPacToGridTodayKwh']), 8)
+    print("")
+
+    indent_print("Imported from Grid (kwh) - NOT TRUSTED:", 6)
+    indent_print("mix_detail['etouser']: %s"%(mix_detail['etouser']), 8)
+    indent_print("mix_detail['calculatedPacToUserTodayKwh']: %s"%(mix_detail['calculatedPacToUserTodayKwh']), 8)
+    print("")
+
+    indent_print("Battery discharge (kwh) - TRUSTED:", 6)
+    indent_print("mix_info['eBatDisChargeToday']: %s"%(mix_info['eBatDisChargeToday']), 8)
+    indent_print("mix_totals['edischarge1Today']: %s"%(mix_totals['edischarge1Today']), 8)
+    indent_print("mix_detail['echarge1']: %s"%(mix_detail['echarge1']), 8)
+    indent_print("mix_detail['calculatedPdischargeTodayKwh']: %s"%(mix_detail['calculatedPdischargeTodayKwh']), 8)
+    print("")
+
+    indent_print("Solar generation (kwh) - TRUSTED:", 6)
+    indent_print("mix_info['epvToday']: %s"%(mix_info['epvToday']), 8)
+    indent_print("mix_totals['epvToday']: %s"%(mix_totals['epvToday']), 8)
+    indent_print("mix_detail['calculatedPpvTodayKwh']: %s"%(mix_detail['calculatedPpvTodayKwh']), 8)
+    print("")
+
+    indent_print("Load Consumption (kwh) - NOT TRUSTED:", 6)
+    indent_print("mix_totals['elocalLoadToday']: %s"%(mix_totals['elocalLoadToday'],), 8)
+    indent_print("mix_detail['elocalLoad']: %s"%(mix_detail['elocalLoad']), 8)
+    indent_print("mix_detail['calculatedSysOutTodayKwh']: %s"%(mix_detail['calculatedSysOutTodayKwh']), 8)
+    print("")
+
+
     #This call gets all of the instantaneous values from the system e.g. current load, generation etc.
     mix_status = api.mix_system_status(device_sn, plant_id)
     #pp.pprint(mix_status)


### PR DESCRIPTION
- Added API calls for Mix Totals & Current system status
- Fixed the `mix_info` function as it was missing the `mix_id` parameter
- Full example added for a 'mix' type system
- Updated the README accordingly

@indykoning - The intention once this is merged is to ask you to do a formal release so that I can then add the Mix functionality to the HomeAssistant integration.