### PR TITLE
Update README.md: Uses https://server.growatt.com (secure)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,6 @@ Any methods that may be useful.
 ### Variables
 Some variables you may want to set.
 
-`api.server_url` The growatt server url, default: 'http://server.growatt.com/'
+`api.server_url` The growatt server url, default: 'https://server.growatt.com/'
 ## Note
 This is based on the endpoints used on the mobile app and could be changed without notice.


### PR DESCRIPTION
The code clearly uses https (secure) as default URL. 
I know from the past the server did not have a certificate.