### PR TITLE
Support for settings on AC-coupled inverters

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,9 +62,7 @@ Any methods that may be useful.
 
 `api.update_plant_settings(plant_id, changed_settings, current_settings)` Update the settings for a plant to the values specified in the dictionary, if the `current_settings` are not provided it will look them up automatically using the `get_plant_settings` function - See 'Plant settings' below for more information
 
-`api.update_mix_inverter_setting(serial_number, setting_type, parameters)` Applies the provided parameters (dictionary or array) for the specified setting on the specified inverter - See 'Inverter settings' below for more information - Appears to be limited to "mix" systems
-
-`api.update_ac_inverter_setting(serial_number, setting_type, parameters)` Applies the provided parameters (dictionary or array) for the specified setting on the specified _AC-coupled_ (rather than mix) inverter - See 'Inverter settings' below for more information
+`api.update_mix_inverter_setting(serial_number, setting_type, parameters)` Applies the provided parameters (dictionary or array) for the specified setting on the specified inverter, `mix` should be set to False if an AC-coupled inverter is used - See 'Inverter settings' below for more information
 
 ### Variables
 
@@ -139,7 +137,7 @@ Known working settings & parameters are as follows (all parameter values are str
     * `param17`: Schedule 3 - End time - Minute e.g. "00" (0 minutes)
     * `param18`: Schedule 3 - Enabled/Disabled (0 = Disabled, 1 = Enabled)
 * **AC-coupled inverter AC charge times**
-  * function: `api.update_ac_inverter_setting`
+  * function: `api.update_mix_inverter_setting`
   * setting type: `spa_ac_charge_time_period`
   * params:
     * `param1`: Charging power % (value between 0 and 100)
@@ -164,7 +162,9 @@ Both of the functions `update_mix_inverter_setting` and `update_ac_inverter_sett
 
 ## Settings Discovery
 
-The settings for the Plant and Inverter have been reverse engineered by using the ShinePhone Android App and the NetCapture SSL application together to inspect the API calls that are made by the application and the parameters that are provided with it. The settings for the AC inverter were determined by examining requests and responses from the Shine web app.
+* The settings for the Plant and Inverter have been reverse engineered by using the ShinePhone Android App and the NetCapture SSL application together to inspect the API calls that are made by the application and the parameters that are provided with it.
+
+* The settings for an AC-coupled inverter were determined by examining requests and responses from the Shine web app.
 
 ## Disclaimer
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Any methods that may be useful.
 
 `api.update_plant_settings(plant_id, changed_settings, current_settings)` Update the settings for a plant to the values specified in the dictionary, if the `current_settings` are not provided it will look them up automatically using the `get_plant_settings` function - See 'Plant settings' below for more information
 
-`api.update_mix_inverter_setting(serial_number, setting_type, parameters)` Applies the provided parameters (dictionary or array) for the specified setting on the specified inverter, `mix` should be set to False if an AC-coupled inverter is used - See 'Inverter settings' below for more information
+`api.update_inverter_setting(serial_number, setting_type, parameters, mix = True)` Applies the provided parameters (dictionary or array) for the specified setting on the specified inverter, `mix` should be set to False if an AC-coupled inverter is used - See 'Inverter settings' below for more information
 
 ### Variables
 
@@ -115,7 +115,7 @@ Known working settings & parameters are as follows (all parameter values are str
   * params:
     * `param1`: datetime in format: `YYYY-MM-DD HH:MM:SS`
 * **Hybrid inverter AC charge times**
-  * function: `api.update_mix_inverter_setting`
+  * function: `api.update_mix_inverter_setting` or `api.update_inverter_setting`
   * setting type: `mix_ac_charge_time_period`
   * params:
     * `param1`: Charging power % (value between 0 and 100)
@@ -137,7 +137,7 @@ Known working settings & parameters are as follows (all parameter values are str
     * `param17`: Schedule 3 - End time - Minute e.g. "00" (0 minutes)
     * `param18`: Schedule 3 - Enabled/Disabled (0 = Disabled, 1 = Enabled)
 * **AC-coupled inverter AC charge times**
-  * function: `api.update_mix_inverter_setting`
+  * function: `api.update_mix_inverter_setting` or `api.update_inverter_setting` with `mix = False`
   * setting type: `spa_ac_charge_time_period`
   * params:
     * `param1`: Charging power % (value between 0 and 100)
@@ -158,13 +158,13 @@ Known working settings & parameters are as follows (all parameter values are str
     * `param16`: Schedule 3 - End time - Minute e.g. "00" (0 minutes)
     * `param17`: Schedule 3 - Enabled/Disabled (0 = Disabled, 1 = Enabled)
 
-Both of the functions `update_mix_inverter_setting` and `update_ac_inverter_setting` take either a dictionary or an array. If an array is passed it will automatically generate the `paramN` key based on array index since all params for settings seem to used the same numbering scheme.
+The three functions `update_mix_inverter_setting`, `update_ac_inverter_setting`, and `update_inverter_setting` take either a dictionary or an array. If an array is passed it will automatically generate the `paramN` key based on array index since all params for settings seem to used the same numbering scheme.
 
 ## Settings Discovery
 
 * The settings for the Plant and Inverter have been reverse engineered by using the ShinePhone Android App and the NetCapture SSL application together to inspect the API calls that are made by the application and the parameters that are provided with it.
 
-* The settings for an AC-coupled inverter were determined by examining requests and responses from the Shine web app.
+* The settings for an AC-coupled inverter were determined by [examining requests and responses from the Shine web app](https://github.com/indykoning/PyPi_GrowattServer/issues/33#issuecomment-1264320814 "@grunkyb tutorial").
 
 ## Disclaimer
 
@@ -175,4 +175,3 @@ The library contains functions that allow you to modify the configuration of you
 To the best of our knowledge only the `settings` functions perform modifications to your system and all other operations are read only. Regardless of the operation:
 
 ***The library is used entirely at your own risk.***
-

--- a/README.md
+++ b/README.md
@@ -164,9 +164,7 @@ The three functions `update_mix_inverter_setting`, `update_ac_inverter_setting`,
 
 ## Settings Discovery
 
-* The settings for the Plant and Inverter have been reverse engineered by using the ShinePhone Android App and the NetCapture SSL application together to inspect the API calls that are made by the application and the parameters that are provided with it.
-
-* The settings for an AC-coupled inverter were determined by [examining requests and responses from the Shine web app](https://github.com/indykoning/PyPi_GrowattServer/issues/33#issuecomment-1264320814 "@grunkyb tutorial").
+The settings for the Plant and Inverter have been reverse engineered by using the ShinePhone Android App and the NetCapture SSL application together to inspect the API calls that are made by the application and the parameters that are provided with it.
 
 ## Disclaimer
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,9 @@ Any methods that may be useful.
 
 `api.update_plant_settings(plant_id, changed_settings, current_settings)` Update the settings for a plant to the values specified in the dictionary, if the `current_settings` are not provided it will look them up automatically using the `get_plant_settings` function - See 'Plant settings' below for more information
 
-`api.update_inverter_setting(serial_number, setting_type, parameters, mix = True)` Applies the provided parameters (dictionary or array) for the specified setting on the specified inverter, `mix` should be set to False if an AC-coupled inverter is used - See 'Inverter settings' below for more information
+`api.update_mix_inverter_setting(serial_number, setting_type, parameters)` Applies the provided parameters (dictionary or array) for the specified setting on the specified mix inverter; see 'Inverter settings' below for more information
+
+`api.update_ac_inverter_setting(serial_number, setting_type, parameters)` Applies the provided parameters (dictionary or array) for the specified setting on the specified AC-coupled inverter; see 'Inverter settings' below for more information
 
 ### Variables
 
@@ -115,7 +117,7 @@ Known working settings & parameters are as follows (all parameter values are str
   * params:
     * `param1`: datetime in format: `YYYY-MM-DD HH:MM:SS`
 * **Hybrid inverter AC charge times**
-  * function: `api.update_mix_inverter_setting` or `api.update_inverter_setting`
+  * function: `api.update_mix_inverter_setting`
   * setting type: `mix_ac_charge_time_period`
   * params:
     * `param1`: Charging power % (value between 0 and 100)
@@ -137,7 +139,7 @@ Known working settings & parameters are as follows (all parameter values are str
     * `param17`: Schedule 3 - End time - Minute e.g. "00" (0 minutes)
     * `param18`: Schedule 3 - Enabled/Disabled (0 = Disabled, 1 = Enabled)
 * **AC-coupled inverter AC charge times**
-  * function: `api.update_mix_inverter_setting` or `api.update_inverter_setting` with `mix = False`
+  * function: `api.update_ac_inverter_setting`
   * setting type: `spa_ac_charge_time_period`
   * params:
     * `param1`: Charging power % (value between 0 and 100)

--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ Any methods that may be useful.
 
 `api.update_mix_inverter_setting(serial_number, setting_type, parameters)` Applies the provided parameters (dictionary or array) for the specified setting on the specified inverter - See 'Inverter settings' below for more information - Appears to be limited to "mix" systems
 
+`api.update_ac_inverter_setting(serial_number, setting_type, parameters)` Applies the provided parameters (dictionary or array) for the specified setting on the specified _AC-coupled_ (rather than mix) inverter - See 'Inverter settings' below for more information
+
 ### Variables
 
 Some variables you may want to set.
@@ -115,7 +117,8 @@ Known working settings & parameters are as follows (all parameter values are str
   * params:
     * `param1`: datetime in format: `YYYY-MM-DD HH:MM:SS`
 * **Hybrid inverter AC charge times**
-  * type: `mix_ac_charge_time_period`
+  * function: `api.update_mix_inverter_setting`
+  * setting type: `mix_ac_charge_time_period`
   * params:
     * `param1`: Charging power % (value between 0 and 100)
     * `param2`: Stop charging Statement of Charge % (value between 0 and 100)
@@ -135,12 +138,33 @@ Known working settings & parameters are as follows (all parameter values are str
     * `param16`: Schedule 3 - End time - Hour e.g. "02" (2am)
     * `param17`: Schedule 3 - End time - Minute e.g. "00" (0 minutes)
     * `param18`: Schedule 3 - Enabled/Disabled (0 = Disabled, 1 = Enabled)
+* **AC-coupled inverter AC charge times**
+  * function: `api.update_ac_inverter_setting`
+  * setting type: `spa_ac_charge_time_period`
+  * params:
+    * `param1`: Charging power % (value between 0 and 100)
+    * `param2`: Stop charging Statement of Charge % (value between 0 and 100)
+    * `param3`: Schedule 1 - Start time - Hour e.g. "01" (1am)
+    * `param4`: Schedule 1 - Start time - Minute e.g. "00" (0 minutes)
+    * `param5`: Schedule 1 - End time - Hour e.g. "02" (2am)
+    * `param6`: Schedule 1 - End time - Minute e.g. "00" (0 minutes)
+    * `param7`: Schedule 1 - Enabled/Disabled (0 = Disabled, 1 = Enabled)
+    * `param8`: Schedule 2 - Start time - Hour e.g. "01" (1am)
+    * `param9`: Schedule 2 - Start time - Minute e.g. "00" (0 minutes)
+    * `param10`: Schedule 2 - End time - Hour e.g. "02" (2am)
+    * `param11`: Schedule 2 - End time - Minute e.g. "00" (0 minutes)
+    * `param12`: Schedule 2 - Enabled/Disabled (0 = Disabled, 1 = Enabled)
+    * `param13`: Schedule 3 - Start time - Hour e.g. "01" (1am)
+    * `param14`: Schedule 3 - Start time - Minute e.g. "00" (0 minutes)
+    * `param15`: Schedule 3 - End time - Hour e.g. "02" (2am)
+    * `param16`: Schedule 3 - End time - Minute e.g. "00" (0 minutes)
+    * `param17`: Schedule 3 - Enabled/Disabled (0 = Disabled, 1 = Enabled)
 
-Note the function `update_mix_inverter_setting` takes either a dictionary or an array, if an array is passed it will automatically generate the `paramN` key based on array index since all params for settings seem to used the same numbering scheme.
+Both of the functions `update_mix_inverter_setting` and `update_ac_inverter_setting` take either a dictionary or an array. If an array is passed it will automatically generate the `paramN` key based on array index since all params for settings seem to used the same numbering scheme.
 
 ## Settings Discovery
 
-The settings for the Plant and Inverter have been reverse engineered by using the ShinePhone Android App and the NetCapture SSL application together to inspect the API calls that are made by the application and the parameters that are provided with it.
+The settings for the Plant and Inverter have been reverse engineered by using the ShinePhone Android App and the NetCapture SSL application together to inspect the API calls that are made by the application and the parameters that are provided with it. The settings for the AC inverter were determined by examining requests and responses from the Shine web app.
 
 ## Disclaimer
 

--- a/examples/settings_example_AC.py
+++ b/examples/settings_example_AC.py
@@ -53,10 +53,9 @@ if login_response['success']:
                          '00','00',      # Schedule 3 - End time
                          '0']            # Schedule 3 - Enabled/Disabled (1 = Enabled)
 
-    response = api.update_inverter_setting(device_sn,
-                                           'spa_ac_charge_time_period',
-                                           schedule_settings,
-                                           mix = False)
+    response = api.update_ac_inverter_setting(device_sn,
+                                              'spa_ac_charge_time_period',
+                                              schedule_settings)
 else:
     response = login_response
 print(json.dumps(response))

--- a/examples/settings_example_AC.py
+++ b/examples/settings_example_AC.py
@@ -53,9 +53,10 @@ if login_response['success']:
                          '00','00',      # Schedule 3 - End time
                          '0']            # Schedule 3 - Enabled/Disabled (1 = Enabled)
 
-    response = api.update_ac_inverter_setting(device_sn,
-                                              'spa_ac_charge_time_period',
-                                              schedule_settings)
+    response = api.update_inverter_setting(device_sn,
+                                           'spa_ac_charge_time_period',
+                                           schedule_settings,
+                                           mix = False)
 else:
     response = login_response
 print(json.dumps(response))

--- a/examples/settings_example_AC.py
+++ b/examples/settings_example_AC.py
@@ -1,0 +1,61 @@
+import growattServer
+import sys
+import json
+'''
+Sample script to set AC battery charging
+Takes commandline arguments for terminal SOC, start time, end time, 
+    and whether to run, with default arguments if none are given
+Tested on an SPA3000
+'''
+
+# check for SOC percent and whether to run 
+if len(sys.argv) != 7:
+    SOC = '40'
+    startH = '0'
+    startM = '40'
+    endH = '04'
+    endM = '30'
+    run = '1'
+else:
+    SOC = str(sys.argv[1])
+    startH = '{:02.0f}'.format(int(sys.argv[2]))
+    startM = '{:02.0f}'.format(int(sys.argv[3]))
+    endH = '{:02.0f}'.format(int(sys.argv[4]))
+    endM = '{:02.0f}'.format(int(sys.argv[5]))
+    run = str(sys.argv[6])
+
+api = growattServer.GrowattApi()
+
+# This part needs to be adapted by the user
+login_response = api.login('USERNAME_AS_STRING',
+                           'PASSWORD_AS_STRING')
+
+if login_response['success']:
+    # Get a list of growatt plants.
+    plant_list = api.plant_list(login_response['user']['id'])
+    plant = plant_list['data'][0]
+    plant_id = plant['plantId']
+    plant_info = api.plant_info(plant_id)
+    device = plant_info['deviceList'][0]
+    device_sn = device['deviceSn']
+
+    # All parameters need to be given, including zeros
+    # All parameters must be strings
+    schedule_settings = ['100',          # Charging power %
+                         SOC,            # Stop charging at SoC %
+                         startH, startM, # Schedule 1 - Start time
+                         endH, endM,     # Schedule 1 - End time
+                         run,            # Schedule 1 - Enabled/Disabled (1 = Enabled)
+                         '00','00',      # Schedule 2 - Start time
+                         '00','00',      # Schedule 2 - End time
+                         '0',            # Schedule 2 - Enabled/Disabled (1 = Enabled)
+                         '00','00',      # Schedule 3 - Start time
+                         '00','00',      # Schedule 3 - End time
+                         '0']            # Schedule 3 - Enabled/Disabled (1 = Enabled)
+
+    response = api.update_ac_inverter_setting(device_sn,
+                                              'spa_ac_charge_time_period',
+                                              schedule_settings)
+else:
+    response = login_response
+print(json.dumps(response))

--- a/growattServer/__init__.py
+++ b/growattServer/__init__.py
@@ -124,7 +124,7 @@ class GrowattApi:
                     'userLevel': data['user']['rightlevel']
                 })
         except:
-            data = {'succsss': False}
+            data = {'success': False}
         return data
 
     def plant_list(self, user_id):

--- a/growattServer/__init__.py
+++ b/growattServer/__init__.py
@@ -116,12 +116,15 @@ class GrowattApi:
             'userName': username,
             'password': password
         })
-        data = json.loads(response.content.decode('utf-8'))['back']
-        if data['success']:
-            data.update({
-                'userId': data['user']['id'],
-                'userLevel': data['user']['rightlevel']
-            })
+        try:
+            data = json.loads(response.content.decode('utf-8'))['back']
+            if data['success']:
+                data.update({
+                    'userId': data['user']['id'],
+                    'userLevel': data['user']['rightlevel']
+                })
+        except:
+            data = {'succsss': False}
         return data
 
     def plant_list(self, user_id):

--- a/growattServer/__init__.py
+++ b/growattServer/__init__.py
@@ -610,7 +610,7 @@ class GrowattApi:
                 settings_parameters['param' + str(index)] = param
         
         settings_parameters = {**default_parameters, **settings_parameters}
-        print(settings_parameters)
+
         response = self.session.post(self.get_url(endpoint), 
                                      params=settings_parameters)
         data = json.loads(response.content.decode('utf-8'))

--- a/growattServer/__init__.py
+++ b/growattServer/__init__.py
@@ -116,15 +116,12 @@ class GrowattApi:
             'userName': username,
             'password': password
         })
-        try:
-            data = json.loads(response.content.decode('utf-8'))['back']
-            if data['success']:
-                data.update({
-                    'userId': data['user']['id'],
-                    'userLevel': data['user']['rightlevel']
-                })
-        except:
-            data = {'success': False}
+        data = json.loads(response.content.decode('utf-8'))['back']
+        if data['success']:
+            data.update({
+                'userId': data['user']['id'],
+                'userLevel': data['user']['rightlevel']
+            })
         return data
 
     def plant_list(self, user_id):

--- a/growattServer/__init__.py
+++ b/growattServer/__init__.py
@@ -590,16 +590,16 @@ class GrowattApi:
         Applies settings for specified system based on serial number
         See README for known working settings
 
-        Keyword arguments:
-            serial_number (str): Serial number (device_sn) of the inverter
-            setting_type (str): Setting to be configured
-            default_params (dict): Default set of parameters for the setting call
-            parameters (dict or list of str): Parameters to be sent to the system 
+        Arguments:
+        serial_number -- Serial number (device_sn) of the inverter (str)
+        setting_type -- Setting to be configured (str)
+        default_params -- Default set of parameters for the setting call (dict)
+        parameters -- Parameters to be sent to the system (dict or list of str)
                 (array which will be converted to a dictionary)
-            endpoint (str): The URL endpoint that should be called
+        endpoint -- The URL endpoint that should be called (str)
 
         Returns:
-            JSON response from the server whether the configuration was successful
+        JSON response from the server whether the configuration was successful
         """
         settings_parameters = parameters
         
@@ -619,6 +619,16 @@ class GrowattApi:
     def update_mix_inverter_setting(self, serial_number, setting_type, parameters):
         """
         Alias for setting inverter parameters on a mix inverter
+        See README for known working settings
+
+        Arguments:
+        serial_number -- Serial number (device_sn) of the inverter (str)
+        setting_type -- Setting to be configured (str)
+        parameters -- Parameters to be sent to the system (dict or list of str)
+                (array which will be converted to a dictionary)
+
+        Returns:
+        JSON response from the server whether the configuration was successful
         """
         default_parameters = {
             'op': 'mixSetApiNew',
@@ -633,6 +643,16 @@ class GrowattApi:
     def update_ac_inverter_setting(self, serial_number, setting_type, parameters):
         """
         Alias for setting inverter parameters on an AC-coupled inverter
+        See README for known working settings
+
+        Arguments:
+        serial_number -- Serial number (device_sn) of the inverter (str)
+        setting_type -- Setting to be configured (str)
+        parameters -- Parameters to be sent to the system (dict or list of str)
+                (array which will be converted to a dictionary)
+
+        Returns:
+        JSON response from the server whether the configuration was successful
         """
         default_parameters = {
             'action': 'spaSet',

--- a/growattServer/__init__.py
+++ b/growattServer/__init__.py
@@ -583,9 +583,8 @@ class GrowattApi:
         data = json.loads(response.content.decode('utf-8'))
         return data
 
-
     def update_inverter_setting(self, serial_number, setting_type, 
-                                default_parameters, parameters, endpoint):
+                                default_parameters, parameters):
         """
         Applies settings for specified system based on serial number
         See README for known working settings
@@ -596,7 +595,6 @@ class GrowattApi:
         default_params -- Default set of parameters for the setting call (dict)
         parameters -- Parameters to be sent to the system (dict or list of str)
                 (array which will be converted to a dictionary)
-        endpoint -- The URL endpoint that should be called (str)
 
         Returns:
         JSON response from the server whether the configuration was successful
@@ -611,7 +609,7 @@ class GrowattApi:
         
         settings_parameters = {**default_parameters, **settings_parameters}
 
-        response = self.session.post(self.get_url(endpoint), 
+        response = self.session.post(self.get_url('newTcpsetAPI.do'), 
                                      params=settings_parameters)
         data = json.loads(response.content.decode('utf-8'))
         return data
@@ -635,10 +633,8 @@ class GrowattApi:
             'serialNum': serial_number,
             'type': setting_type
         }
-        endpoint = 'newTcpsetAPI.do'
         return self.update_inverter_setting(serial_number, setting_type, 
-                                            default_parameters, parameters, 
-                                            endpoint)
+                                            default_parameters, parameters)
 
     def update_ac_inverter_setting(self, serial_number, setting_type, parameters):
         """
@@ -655,11 +651,9 @@ class GrowattApi:
         JSON response from the server whether the configuration was successful
         """
         default_parameters = {
-            'action': 'spaSet',
+            'op': 'spaSetApi',
             'serialNum': serial_number,
             'type': setting_type
         }
-        endpoint = 'tcpSet.do'
         return self.update_inverter_setting(serial_number, setting_type, 
-                                            default_parameters, parameters, 
-                                            endpoint)
+                                            default_parameters, parameters)

--- a/growattServer/__init__.py
+++ b/growattServer/__init__.py
@@ -613,3 +613,34 @@ class GrowattApi:
         response = self.session.post(self.get_url('newTcpsetAPI.do'), params=settings_params)
         data = json.loads(response.content.decode('utf-8'))
         return data
+
+    def update_ac_inverter_setting(self, serial_number, setting_type, parameters):
+        """
+        Applies settings for specified system based on serial number
+        See README for known working settings
+
+        Keyword arguments:
+        serial_number -- The serial number (device_sn) of the inverter
+        setting_type -- The setting to be configured (list of known working settings below)
+        parameters -- A python dictionary of the parameters to be sent to the system based on the chosen setting_type, OR a python array which will be converted to a params dictionary
+
+        Returns:
+        A response from the server stating whether the configuration was successful or not
+        """
+        setting_parameters = parameters
+
+        #If we've been passed an array then convert it into a dictionary
+        if isinstance(parameters, list):
+            setting_parameters = {}
+            for index, param in enumerate(parameters, start=1):
+                setting_parameters['param' + str(index)] = param
+
+        default_params = {
+            'action': 'spaSet',
+            'serialNum': serial_number,
+            'type': setting_type
+        }
+        settings_params = {**default_params, **setting_parameters}
+        response = self.session.post(self.get_url('tcpSet.do'), params=settings_params)
+        data = json.loads(response.content.decode('utf-8'))
+        return data

--- a/growattServer/__init__.py
+++ b/growattServer/__init__.py
@@ -583,45 +583,36 @@ class GrowattApi:
         data = json.loads(response.content.decode('utf-8'))
         return data
 
-    def update_inverter_setting(self, serial_number, setting_type, parameters, mix = True):
+
+    def update_inverter_setting(self, serial_number, setting_type, 
+                                default_parameters, parameters, endpoint):
         """
         Applies settings for specified system based on serial number
         See README for known working settings
 
         Keyword arguments:
-        serial_number -- The serial number (device_sn) of the inverter
-        setting_type -- The setting to be configured (list of known working settings below)
-        parameters -- A python dictionary of the parameters to be sent to the system based on the chosen setting_type, OR a python array which will be converted to a params dictionary
-        mix -- Boolean, true for mix inverters, false for AC-coupled inverters
-        
-        Returns:
-        A response from the server stating whether the configuration was successful or not
-        """
-        setting_parameters = parameters
+            serial_number (str): Serial number (device_sn) of the inverter
+            setting_type (str): Setting to be configured
+            default_params (dict): Default set of parameters for the setting call
+            parameters (dict or list of str): Parameters to be sent to the system 
+                (array which will be converted to a dictionary)
+            endpoint (str): The URL endpoint that should be called
 
+        Returns:
+            JSON response from the server whether the configuration was successful
+        """
+        settings_parameters = parameters
+        
         #If we've been passed an array then convert it into a dictionary
         if isinstance(parameters, list):
-            setting_parameters = {}
+            settings_parameters = {}
             for index, param in enumerate(parameters, start=1):
-                setting_parameters['param' + str(index)] = param
-                
-        if mix:
-            default_params = {
-                'op': 'mixSetApiNew',
-                'serialNum': serial_number,
-                'type': setting_type
-            }
-            url = 'newTcpsetAPI.do'
-        else:
-            default_params = {
-                'action': 'spaSet',
-                'serialNum': serial_number,
-                'type': setting_type
-            }
-            url = 'tcpSet.do'
+                settings_parameters['param' + str(index)] = param
         
-        settings_params = {**default_params, **setting_parameters}
-        response = self.session.post(self.get_url(url), params=settings_params)
+        settings_parameters = {**default_parameters, **settings_parameters}
+        print(settings_parameters)
+        response = self.session.post(self.get_url(endpoint), 
+                                     params=settings_parameters)
         data = json.loads(response.content.decode('utf-8'))
         return data
 
@@ -629,10 +620,26 @@ class GrowattApi:
         """
         Alias for setting inverter parameters on a mix inverter
         """
-        return self.update_inverter_setting(serial_number, setting_type, parameters, mix = True)
+        default_parameters = {
+            'op': 'mixSetApiNew',
+            'serialNum': serial_number,
+            'type': setting_type
+        }
+        endpoint = 'newTcpsetAPI.do'
+        return self.update_inverter_setting(serial_number, setting_type, 
+                                            default_parameters, parameters, 
+                                            endpoint)
 
     def update_ac_inverter_setting(self, serial_number, setting_type, parameters):
         """
         Alias for setting inverter parameters on an AC-coupled inverter
         """
-        return self.update_inverter_setting(serial_number, setting_type, parameters, mix = False)
+        default_parameters = {
+            'action': 'spaSet',
+            'serialNum': serial_number,
+            'type': setting_type
+        }
+        endpoint = 'tcpSet.do'
+        return self.update_inverter_setting(serial_number, setting_type, 
+                                            default_parameters, parameters, 
+                                            endpoint)


### PR DESCRIPTION
- Added a function to support changing the settings on an AC-coupled Growatt inverter (tested on Growatt SPA3000)
- Added an example script to set the battery on an AC coupled inverter
- Added a try/catch for login
- Updated README.md to describe new functions