### PR TITLE
Add custom user-agent headers

### DIFF
--- a/growattServer/__init__.py
+++ b/growattServer/__init__.py
@@ -27,6 +27,8 @@ class GrowattApi:
 
     def __init__(self):
         self.session = requests.Session()
+        headers = {'User-Agent': 'Dalvik/2.1.0 (Linux; U; Android'}
+        self.session.headers.update(headers)
 
     def __get_date_string(self, timespan=None, date=None):
         if timespan is not None:


### PR DESCRIPTION
Fix for https://github.com/indykoning/PyPi_GrowattServer/issues/36

NOTE - The 'User-Agent' header can actually be set to anything, including an empty string. However, I wanted to make it look as close as possible to an actual Android device so it's not easy to filter out on the growatt server side i.e. reducing the likelihood of getting blocked again in the future.

I'm happy to take an alternative solution, but this is the best that I could come up with.

Once merged & released this will also need to be updated on the HA integration to resolve this problem: https://github.com/home-assistant/core/issues/80950