### PR TITLE
Change headers to Android device

### DIFF
--- a/growattServer/__init__.py
+++ b/growattServer/__init__.py
@@ -27,7 +27,7 @@ class GrowattApi:
 
     def __init__(self):
         self.session = requests.Session()
-        headers = {'User-Agent': 'Dalvik/2.1.0 (Linux; U; Android'}
+        headers = {'User-Agent': 'Dalvik/2.1.0 (Linux; U; Android Device)'}
         self.session.headers.update(headers)
 
     def __get_date_string(self, timespan=None, date=None):


### PR DESCRIPTION
Changing headers to workaround issue #38 

My plan is to submit a better fix for this next week, however we need a release of this as I'm not allowed to submit header information directly into the Home Assistant integration.

@indykoning - As mentioned on #38 - I'll send you an email with a suggestion about how I'd like to implement a 'proper' fix for this over the weekend.

Would be grateful though if you could merge and release this soon so I can get a build into HomeAssistant.