### PR TITLE
Added optional (defaults off) auto-generation of User-Agent field when library is started

### DIFF
--- a/examples/mix_example.py
+++ b/examples/mix_example.py
@@ -33,7 +33,10 @@ username=input("Enter username:")
 #Prompt user to input password
 user_pass=getpass.getpass("Enter password:")
 
-api = growattServer.GrowattApi()
+#Setting generate_user_agent to True will auto generate a User-Agent every run, leaving it False will use the default
+#Can override the default with 'user_agent' param
+api = growattServer.GrowattApi(generate_user_agent=False)
+print(("User-Agent being used: %s") % api.user_agent)
 login_response = api.login(username, user_pass)
 
 plant_list = api.plant_list(login_response['user']['id'])


### PR DESCRIPTION
I know I said I'd email you about this implementation @indykoning however I thought it would be best to just implement it and then discuss it here.

This is a completely backwards compatible change that allows a user of the library to either:

1. Auto-generate a User-Agent string by pulling it from a valid source online, this is then used for the duration of the api object
2. Specify their own User-Agent string (which is what is defaulted to if the auto-generate fails for any reason)
3. (Default) - Use the default value of the User-Agent string which was introduced in 1.2.3

This way users are able to control what they use as the User-Agent until we can get Growatt to properly engage about what throttling they are doing with the library.

My plan for Home Assistant is to allow users to optionally specify their own User-Agent field i.e. match the one used on their mobile phone, or fall back to a randomly generated one.

NOTE - I want to also update the README file for this before it is merged, but I figured we'd end up discussing it here first, once we've finalised the implementation then I'll update the documentation.