### PR TITLE
Change Growatt Server URL.

### DIFF
--- a/growattServer/__init__.py
+++ b/growattServer/__init__.py
@@ -24,7 +24,7 @@ class Timespan(IntEnum):
     month = 2
 
 class GrowattApi:
-    server_url = 'https://server-api.growatt.com/'
+    server_url = 'https://server.growatt.com/'
     agent_identifier = "Dalvik/2.1.0 (Linux; U; Android 12; https://github.com/indykoning/PyPi_GrowattServer)"
 
     def __init__(self, add_random_user_id=False, agent_identifier=None):


### PR DESCRIPTION
Current package throws a 403, unless you use the new server URL.