### PR TITLE
url change, new endpoint to plant_list and more timespan options

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Any methods that may be useful.
 
 `api.plant_info(plant_id)` Get info for specified plant.
 
-`api.plant_detail(plant_id, timespan<1=day, 2=month>, date)` Get details of a specific plant.
+`api.plant_detail(plant_id, timespan<1=day, 2=month, 3=year, 4=all>, date)` Get details of a specific plant.
 
 `api.inverter_list(plant_id)` Get a list of inverters in specified plant. (May be deprecated in the future, since it gets all devices. Use `device_list` instead).
 

--- a/growattServer/__init__.py
+++ b/growattServer/__init__.py
@@ -157,7 +157,7 @@ class GrowattApi:
         """
         date_str = self.__get_date_string(timespan, date)
 
-        response = self.session.get(self.get_url('PlantDetailAPI.do'), params={
+        response = self.session.get(self.get_url('newPlantDetailAPI.do'), params={
             'plantId': plant_id,
             'type': timespan.value,
             'date': date_str

--- a/growattServer/__init__.py
+++ b/growattServer/__init__.py
@@ -22,6 +22,8 @@ class Timespan(IntEnum):
     hour = 0
     day = 1
     month = 2
+    year = 3
+    all = 4
 
 class GrowattApi:
     server_url = 'https://server.growatt.com/'
@@ -54,8 +56,10 @@ class GrowattApi:
         date_str=""
         if timespan == Timespan.month:
             date_str = date.strftime('%Y-%m')
-        else:
+        elif timespan == Timespan.day or timespan == Timespan.hour:
             date_str = date.strftime('%Y-%m-%d')
+        else:
+            date_str = date.strftime('%Y')
 
         return date_str
 

--- a/growattServer/__init__.py
+++ b/growattServer/__init__.py
@@ -160,7 +160,8 @@ class GrowattApi:
         response = self.session.get(self.get_url('newPlantDetailAPI.do'), params={
             'plantId': plant_id,
             'type': timespan.value,
-            'date': date_str
+            'date': date_str,
+            'dataType' : 0
         })
         data = json.loads(response.content.decode('utf-8'))
         return data['back']

--- a/growattServer/__init__.py
+++ b/growattServer/__init__.py
@@ -160,8 +160,7 @@ class GrowattApi:
         response = self.session.get(self.get_url('newPlantDetailAPI.do'), params={
             'plantId': plant_id,
             'type': timespan.value,
-            'date': date_str,
-            'dataType' : 0
+            'date': date_str
         })
         data = json.loads(response.content.decode('utf-8'))
         return data['back']

--- a/growattServer/__init__.py
+++ b/growattServer/__init__.py
@@ -24,7 +24,7 @@ class Timespan(IntEnum):
     month = 2
 
 class GrowattApi:
-    server_url = 'https://server-api.growatt.com/'
+    server_url = 'https://server.growatt.com/'
     agent_identifier = "Dalvik/2.1.0 (Linux; U; Android 12; https://github.com/indykoning/PyPi_GrowattServer)"
 
     def __init__(self, add_random_user_id=False, agent_identifier=None):


### PR DESCRIPTION
server_url change, same as pr https://github.com/indykoning/PyPi_GrowattServer/pull/62
endpoint for plant_detail changed from `PlantDetailAPI` to `newPlantDetailAPI`, retrieving complete date on data dict
added 2 more timespan options, `year` and `all`
> ```
> class Timespan(IntEnum):
>    hour = 0
>    day = 1
>    month = 2
>    year = 3
>    all = 4
> ```