### PR TITLE
Update default url to openapi.growatt.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,13 @@ Any methods that may be useful.
 
 Some variables you may want to set.
 
-`api.server_url` The growatt server URL, default: 'https://server-api.growatt.com/'
+`api.server_url` The growatt server URL, default: 'https://openapi.growatt.com/'
+
+You may need a different URL depending on where your account is registered:
+
+'https://openapi-cn.growatt.com/' (Chinese server)
+'https://openapi-us.growatt.com/' (North American server)
+'https://openapi.growatt.com/' (Other regional server: e.g. Europe)
 
 ## Note
 

--- a/growattServer/__init__.py
+++ b/growattServer/__init__.py
@@ -24,7 +24,7 @@ class Timespan(IntEnum):
     month = 2
 
 class GrowattApi:
-    server_url = 'https://server-api.growatt.com/'
+    server_url = 'https://openapi.growatt.com/'
     agent_identifier = "Dalvik/2.1.0 (Linux; U; Android 12; https://github.com/indykoning/PyPi_GrowattServer)"
 
     def __init__(self, add_random_user_id=False, agent_identifier=None):


### PR DESCRIPTION
Fixes https://github.com/indykoning/PyPi_GrowattServer/issues/74 

Based on the similar change applied to Home Assistant: https://github.com/home-assistant/core/pull/109122
The PR author there received these URLs from the Growatt IT department.

I also found this document online, probably originating from Growatt as well, mensioning the same URLs:
https://www.showdoc.com.cn/262556420217021/1494054927748011
![image](https://github.com/indykoning/PyPi_GrowattServer/assets/438046/82420f6f-0f4d-4a79-a7d5-941e237d0e71)

