### PR TITLE
Add get_mix_inverter_settings method

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ Any methods that may be useful.
 
 `api.get_plant_settings(plant_id)` Get the current settings for the specified plant
 
+`api.get_mix_inverter_settings(serial_number)` Get the current inverter settings for the specified serial number including charge/discharge schedule for hybrid systems.
+
 `api.update_plant_settings(plant_id, changed_settings, current_settings)` Update the settings for a plant to the values specified in the dictionary, if the `current_settings` are not provided it will look them up automatically using the `get_plant_settings` function - See 'Plant settings' below for more information
 
 `api.update_mix_inverter_setting(serial_number, setting_type, parameters)` Applies the provided parameters (dictionary or array) for the specified setting on the specified mix inverter; see 'Inverter settings' below for more information

--- a/examples/settings_example.py
+++ b/examples/settings_example.py
@@ -40,7 +40,9 @@ device_type = device['deviceType']
 current_settings = api.get_plant_settings(plant_id)
 #pp.pprint(current_settings)
 
-
+#Get mix inverter settings
+inverter_settings = api.get_mix_inverter_settings(device_sn)
+pp.pprint(inverter_settings)
 
 #Change the timezone of the plant
 plant_settings_changes = {

--- a/growattServer/__init__.py
+++ b/growattServer/__init__.py
@@ -669,3 +669,23 @@ class GrowattApi:
         }
         return self.update_inverter_setting(serial_number, setting_type, 
                                             default_parameters, parameters)
+    
+        def get_mix_inverter_settings(self, serial_number):
+
+        """
+        Gets the inverter settings related to battery modes
+        Keyword arguments:
+        serial_number -- The serial number (device_sn) of the inverter
+        Returns:
+        A dictionary of settings
+        """
+
+        default_params = {
+            'op': 'getMixSetParams',
+            'serialNum': serial_number,
+            'kind': 0
+        }
+        settings_params = {**default_params}
+        response = self.session.get(self.get_url('newMixApi.do'), params=default_params)
+        data = json.loads(response.content.decode('utf-8'))
+        return data

--- a/growattServer/__init__.py
+++ b/growattServer/__init__.py
@@ -670,8 +670,7 @@ class GrowattApi:
         return self.update_inverter_setting(serial_number, setting_type, 
                                             default_parameters, parameters)
     
-        def get_mix_inverter_settings(self, serial_number):
-
+    def get_mix_inverter_settings(self, serial_number):
         """
         Gets the inverter settings related to battery modes
         Keyword arguments:
@@ -685,7 +684,6 @@ class GrowattApi:
             'serialNum': serial_number,
             'kind': 0
         }
-        settings_params = {**default_params}
         response = self.session.get(self.get_url('newMixApi.do'), params=default_params)
         data = json.loads(response.content.decode('utf-8'))
         return data


### PR DESCRIPTION
Introduces the PR from the original repo here: https://github.com/indykoning/PyPi_GrowattServer/pull/59 with the suggested fixes.

Also adds the new method to the settings example.

For more details please see the original PR.