### PR TITLE
Add plant power overview method

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ Any methods that may be useful.
 
 `api.plant_energy_overview(plant_id)` Get energy overview data for a plant, using public v1 API.
 
+`api.plant_power_overview(plant_id, day)` Get power data from a specific power station, recorded every 5 minutes for one day.
+
 `api.plant_energy_history(plant_id, start_date, end_date, time_unit, page, perpage)` Get historical energy data for a plant for multiple days/months/years, using public v1 API.
 
 `api.device_list(plant_id)` Get a list of devices in specified plant using the public v1 API.

--- a/growattServer/open_api_v1.py
+++ b/growattServer/open_api_v1.py
@@ -136,7 +136,7 @@ class OpenApiV1(GrowattApi):
 
         return self._process_response(response.json(), "getting plant energy overview")
 
-    def plant_power_overview(self, plant_id: int, day: str | Date = None) -> dict:
+    def plant_power_overview(self, plant_id: int, day: str | date = None) -> dict:
         """
         Obtain power data of a certain power station.
         Get the frequency once every 5 minutes

--- a/growattServer/open_api_v1.py
+++ b/growattServer/open_api_v1.py
@@ -136,6 +136,45 @@ class OpenApiV1(GrowattApi):
 
         return self._process_response(response.json(), "getting plant energy overview")
 
+    def plant_power_overview(self, plant_id: int, day: str | Date = None) -> dict:
+        """
+        Obtain power data of a certain power station.
+        Get the frequency once every 5 minutes
+
+        Args:
+            plant_id (int): Power Station ID
+            day (date): Date - defaults to today
+
+        Returns:
+            dict: A dictionary containing the plants power data.
+            .. code-block:: python
+
+                {
+                    'count': int,  # Total number of records
+                    'powers': list[dict],  # List of power data entries
+                    # Each entry in 'powers' is a dictionary with:
+                    #   'time': str,  # Time of the power reading
+                    #   'power': float | None  # Power value in Watts (can be None)
+                }
+        Raises:
+            GrowattV1ApiError: If the API returns an error response.
+            requests.exceptions.RequestException: If there is an issue with the HTTP request.
+
+        API-Doc: https://www.showdoc.com.cn/262556420217021/1494062656174173
+        """
+        if day is None:
+            day = date.today()
+
+        response = self.session.get(
+            self._get_url('plant/power'),
+            params={
+                'plant_id': plant_id,
+                'date': day,
+            }
+        )
+
+        return self._process_response(response.json(), "getting plant power overview")
+
     def plant_energy_history(self, plant_id, start_date=None, end_date=None, time_unit="day", page=None, perpage=None):
         """
         Retrieve plant energy data for multiple days/months/years.


### PR DESCRIPTION
Adds a method to retrieve the power data of a day from the API interface. (return data in 5 minute steps)

Docs: https://www.showdoc.com.cn/262556420217021/1494062656174173