### PR TITLE
Add PEP 561 typing to enable static type checking for consumers

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -22,6 +22,7 @@ ignore = [
     "ERA001", # Commented out code is allowed for examples
     "T201", # Prints are allowed in examples
     "PLR0913",
+    "FBT001", # Boolean positional args are part of the existing public API
     "FBT002",
     "N999",
 ]

--- a/growattServer/__init__.py
+++ b/growattServer/__init__.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 """growattServer package exports."""
 
+from __future__ import annotations
+
 from .base_api import GrowattApi, Timespan, hash_password
 from .exceptions import (
     GrowattError,

--- a/growattServer/base_api.py
+++ b/growattServer/base_api.py
@@ -2,6 +2,8 @@
 
 # ruff: noqa: S324
 
+from __future__ import annotations
+
 import datetime
 import hashlib
 import json
@@ -9,6 +11,7 @@ import re
 import secrets
 import warnings
 from enum import IntEnum
+from typing import Any
 
 import requests
 
@@ -21,7 +24,7 @@ BATT_MODE_BATTERY_FIRST = 1
 BATT_MODE_GRID_FIRST = 2
 
 
-def hash_password(password):
+def hash_password(password: str) -> str:
     """
     Return a modified MD5-like hex digest with 'c' substitutions.
 
@@ -49,7 +52,7 @@ class GrowattApi:
     server_url = "https://openapi.growatt.com/"
     agent_identifier = "Dalvik/2.1.0 (Linux; U; Android 12; https://github.com/indykoning/PyPi_GrowattServer)"
 
-    def __init__(self, add_random_user_id=False, agent_identifier=None) -> None:
+    def __init__(self, add_random_user_id: bool = False, agent_identifier: str | None = None) -> None:
         """
         Initialize the Growatt API client.
 
@@ -78,7 +81,7 @@ class GrowattApi:
         headers = {"User-Agent": self.agent_identifier}
         self.session.headers.update(headers)
 
-    def __get_date_string(self, timespan=None, date=None):
+    def __get_date_string(self, timespan: Timespan | None = None, date: datetime.datetime | None = None) -> str:
         if timespan is not None and not isinstance(timespan, Timespan):
             raise ValueError("timespan must be a Timespan enum value")
 
@@ -93,11 +96,11 @@ class GrowattApi:
 
         return date_str
 
-    def get_url(self, page):
+    def get_url(self, page: str) -> str:
         """Return the page URL."""
         return self.server_url + page
 
-    def login(self, username, password, is_password_hashed=False):
+    def login(self, username: str, password: str, is_password_hashed: bool = False) -> dict[str, Any]:
         """
         Log the user in.
 
@@ -175,7 +178,7 @@ class GrowattApi:
             })
         return data
 
-    def plant_list(self, user_id):
+    def plant_list(self, user_id: str) -> list[dict[str, Any]]:
         """
         Get a list of plants connected to this account.
 
@@ -197,7 +200,7 @@ class GrowattApi:
 
         return response.json().get("back", [])
 
-    def plant_detail(self, plant_id, timespan, date=None):
+    def plant_detail(self, plant_id: str, timespan: Timespan, date: datetime.datetime | None = None) -> dict[str, Any]:
         """
         Get plant details for specified timespan.
 
@@ -223,7 +226,7 @@ class GrowattApi:
 
         return response.json().get("back", {})
 
-    def plant_list_two(self):
+    def plant_list_two(self) -> list[dict[str, Any]]:
         """
         Get a list of all plants with detailed information.
 
@@ -247,7 +250,7 @@ class GrowattApi:
 
         return response.json().get("PlantList", [])
 
-    def inverter_data(self, inverter_id, date=None):
+    def inverter_data(self, inverter_id: str, date: datetime.datetime | None = None) -> dict[str, Any]:
         """
         Get inverter data for specified date or today.
 
@@ -272,7 +275,7 @@ class GrowattApi:
 
         return response.json()
 
-    def inverter_detail(self, inverter_id):
+    def inverter_detail(self, inverter_id: str) -> dict[str, Any]:
         """
         Get detailed data from PV inverter.
 
@@ -293,7 +296,7 @@ class GrowattApi:
 
         return response.json()
 
-    def inverter_detail_two(self, inverter_id):
+    def inverter_detail_two(self, inverter_id: str) -> dict[str, Any]:
         """
         Get detailed data from PV inverter (alternative endpoint).
 
@@ -314,7 +317,7 @@ class GrowattApi:
 
         return response.json()
 
-    def tlx_system_status(self, plant_id, tlx_id):
+    def tlx_system_status(self, plant_id: str, tlx_id: str) -> dict[str, Any]:
         """
         Get status of the system.
 
@@ -338,7 +341,7 @@ class GrowattApi:
 
         return response.json().get("obj", {})
 
-    def tlx_energy_overview(self, plant_id, tlx_id):
+    def tlx_energy_overview(self, plant_id: str, tlx_id: str) -> dict[str, Any]:
         """
         Get energy overview.
 
@@ -362,7 +365,7 @@ class GrowattApi:
 
         return response.json().get("obj", {})
 
-    def tlx_energy_prod_cons(self, plant_id, tlx_id, timespan=Timespan.hour, date=None):
+    def tlx_energy_prod_cons(self, plant_id: str, tlx_id: str, timespan: Timespan = Timespan.hour, date: datetime.datetime | None = None) -> dict[str, Any]:
         """
         Get energy production and consumption (kW).
 
@@ -393,7 +396,7 @@ class GrowattApi:
 
         return response.json().get("obj", {})
 
-    def tlx_data(self, tlx_id, date=None):
+    def tlx_data(self, tlx_id: str, date: datetime.datetime | None = None) -> dict[str, Any]:
         """
         Get TLX inverter data for specified date or today.
 
@@ -418,7 +421,7 @@ class GrowattApi:
 
         return response.json()
 
-    def tlx_detail(self, tlx_id):
+    def tlx_detail(self, tlx_id: str) -> dict[str, Any]:
         """
         Get detailed data from TLX inverter.
 
@@ -439,7 +442,7 @@ class GrowattApi:
 
         return response.json()
 
-    def tlx_params(self, tlx_id):
+    def tlx_params(self, tlx_id: str) -> dict[str, Any]:
         """
         Get parameters for TLX inverter.
 
@@ -460,7 +463,7 @@ class GrowattApi:
 
         return response.json()
 
-    def tlx_all_settings(self, tlx_id):
+    def tlx_all_settings(self, tlx_id: str) -> dict[str, Any] | None:
         """
         Get all possible settings from TLX inverter.
 
@@ -482,7 +485,7 @@ class GrowattApi:
 
         return response.json().get("obj", {}).get("tlxSetBean")
 
-    def tlx_enabled_settings(self, tlx_id):
+    def tlx_enabled_settings(self, tlx_id: str) -> dict[str, Any]:
         """
         Get "Enabled settings" from TLX inverter.
 
@@ -505,7 +508,7 @@ class GrowattApi:
 
         return response.json().get("obj", {})
 
-    def tlx_battery_info(self, serial_num):
+    def tlx_battery_info(self, serial_num: str) -> dict[str, Any]:
         """
         Get battery information.
 
@@ -527,7 +530,7 @@ class GrowattApi:
 
         return response.json().get("obj", {})
 
-    def tlx_battery_info_detailed(self, plant_id, serial_num):
+    def tlx_battery_info_detailed(self, plant_id: str, serial_num: str) -> dict[str, Any]:
         """
         Get detailed battery information.
 
@@ -550,7 +553,7 @@ class GrowattApi:
 
         return response.json()
 
-    def mix_info(self, mix_id, plant_id=None):
+    def mix_info(self, mix_id: str, plant_id: str | None = None) -> dict[str, Any]:
         """
         Get high-level values from a Mix device.
 
@@ -596,7 +599,7 @@ class GrowattApi:
 
         return response.json().get("obj", {})
 
-    def mix_totals(self, mix_id, plant_id):
+    def mix_totals(self, mix_id: str, plant_id: str) -> dict[str, Any]:
         """
         Get totals values from a Mix device.
 
@@ -629,7 +632,7 @@ class GrowattApi:
 
         return response.json().get("obj", {})
 
-    def mix_system_status(self, mix_id, plant_id):
+    def mix_system_status(self, mix_id: str, plant_id: str) -> dict[str, Any]:
         """
         Get current status from a Mix device.
 
@@ -673,7 +676,7 @@ class GrowattApi:
 
         return response.json().get("obj", {})
 
-    def mix_detail(self, mix_id, plant_id, timespan=Timespan.hour, date=None):
+    def mix_detail(self, mix_id: str, plant_id: str, timespan: Timespan = Timespan.hour, date: datetime.datetime | None = None) -> dict[str, Any]:
         """
         Get Mix details for the given timespan.
 
@@ -739,7 +742,7 @@ class GrowattApi:
 
         return response.json().get("obj", {})
 
-    def get_mix_inverter_settings(self, serial_number):
+    def get_mix_inverter_settings(self, serial_number: str) -> dict[str, Any]:
         """
         Get the inverter settings related to battery modes.
 
@@ -758,7 +761,7 @@ class GrowattApi:
         response = self.session.get(self.get_url("newMixApi.do"), params=default_params)
         return response.json()
 
-    def dashboard_data(self, plant_id, timespan=Timespan.hour, date=None):
+    def dashboard_data(self, plant_id: str, timespan: Timespan = Timespan.hour, date: datetime.datetime | None = None) -> dict[str, Any]:
         """
         Get dashboard data for a plant over a timespan.
 
@@ -814,7 +817,7 @@ class GrowattApi:
         })
         return response.json()
 
-    def plant_settings(self, plant_id):
+    def plant_settings(self, plant_id: str) -> dict[str, Any]:
         """
         Get a dictionary containing the settings for the specified plant.
 
@@ -832,7 +835,7 @@ class GrowattApi:
 
         return response.json()
 
-    def storage_detail(self, storage_id):
+    def storage_detail(self, storage_id: str) -> dict[str, Any]:
         """Get "All parameters" from battery storage."""
         response = self.session.get(self.get_url("newStorageAPI.do"), params={
             "op": "getStorageInfo_sacolar",
@@ -841,7 +844,7 @@ class GrowattApi:
 
         return response.json()
 
-    def storage_params(self, storage_id):
+    def storage_params(self, storage_id: str) -> dict[str, Any]:
         """Get much more detail from battery storage."""
         response = self.session.get(self.get_url("newStorageAPI.do"), params={
             "op": "getStorageParams_sacolar",
@@ -850,7 +853,7 @@ class GrowattApi:
 
         return response.json()
 
-    def storage_energy_overview(self, plant_id, storage_id):
+    def storage_energy_overview(self, plant_id: str, storage_id: str) -> dict[str, Any]:
         """Get some energy/generation overview data."""
         response = self.session.post(self.get_url("newStorageAPI.do?op=getEnergyOverviewData_sacolar"), params={
             "plantId": plant_id,
@@ -859,13 +862,13 @@ class GrowattApi:
 
         return response.json().get("obj", {})
 
-    def inverter_list(self, plant_id):
+    def inverter_list(self, plant_id: str) -> list[dict[str, Any]]:
         """Use device_list, it's more descriptive since the list contains more than inverters."""
         warnings.warn(
             "This function may be deprecated in the future because naming is not correct, use device_list instead", DeprecationWarning, stacklevel=2)
         return self.device_list(plant_id)
 
-    def __get_all_devices(self, plant_id):
+    def __get_all_devices(self, plant_id: str) -> dict[str, Any]:
         """Get basic plant information with device list."""
         response = self.session.get(self.get_url("newTwoPlantAPI.do"),
                                     params={"op": "getAllDeviceList",
@@ -874,7 +877,7 @@ class GrowattApi:
 
         return response.json().get("deviceList", {})
 
-    def device_list(self, plant_id):
+    def device_list(self, plant_id: str) -> list[dict[str, Any]]:
         """Get a list of all devices connected to plant."""
         device_list = self.plant_info(plant_id).get("deviceList", [])
 
@@ -884,7 +887,7 @@ class GrowattApi:
 
         return device_list
 
-    def plant_info(self, plant_id):
+    def plant_info(self, plant_id: str) -> dict[str, Any]:
         """Get basic plant information with device list."""
         response = self.session.get(self.get_url("newTwoPlantAPI.do"), params={
             "op": "getAllDeviceListTwo",
@@ -895,7 +898,7 @@ class GrowattApi:
 
         return response.json()
 
-    def plant_energy_data(self, plant_id):
+    def plant_energy_data(self, plant_id: str) -> dict[str, Any]:
         """Get the energy data used in the 'Plant' tab in the phone."""
         response = self.session.post(self.get_url("newTwoPlantAPI.do"),
                                      params={
@@ -905,7 +908,7 @@ class GrowattApi:
 
         return response.json()
 
-    def is_plant_noah_system(self, plant_id):
+    def is_plant_noah_system(self, plant_id: str) -> dict[str, Any]:
         """
         Check whether a plant is a Noah system.
 
@@ -929,7 +932,7 @@ class GrowattApi:
         })
         return response.json()
 
-    def noah_system_status(self, serial_number):
+    def noah_system_status(self, serial_number: str) -> dict[str, Any]:
         """
         Get the Noah device status.
 
@@ -964,7 +967,7 @@ class GrowattApi:
         })
         return response.json()
 
-    def noah_info(self, serial_number):
+    def noah_info(self, serial_number: str) -> dict[str, Any]:
         """
         Get detailed Noah device information.
 
@@ -1011,7 +1014,7 @@ class GrowattApi:
         })
         return response.json()
 
-    def update_plant_settings(self, plant_id, changed_settings, current_settings=None):
+    def update_plant_settings(self, plant_id: str, changed_settings: dict[str, Any], current_settings: dict[str, Any] | None = None) -> dict[str, Any]:
         """
         Update plant settings.
 
@@ -1060,8 +1063,8 @@ class GrowattApi:
 
         return response.json()
 
-    def update_inverter_setting(self, serial_number, setting_type,
-                                default_parameters, parameters):
+    def update_inverter_setting(self, serial_number: str, setting_type: str,
+                                default_parameters: dict[str, Any], parameters: dict[str, Any] | list[Any]) -> dict[str, Any]:
         """
         Apply inverter settings.
 
@@ -1105,7 +1108,7 @@ class GrowattApi:
 
         return response.json()
 
-    def update_mix_inverter_setting(self, serial_number, setting_type, parameters):
+    def update_mix_inverter_setting(self, serial_number: str, setting_type: str, parameters: dict[str, Any] | list[Any]) -> dict[str, Any]:
         """
         Set inverter parameters for a Mix inverter.
 
@@ -1126,7 +1129,7 @@ class GrowattApi:
         return self.update_inverter_setting(serial_number, setting_type,
                                             default_parameters, parameters)
 
-    def update_ac_inverter_setting(self, serial_number, setting_type, parameters):
+    def update_ac_inverter_setting(self, serial_number: str, setting_type: str, parameters: dict[str, Any] | list[Any]) -> dict[str, Any]:
         """
         Set inverter parameters for an AC-coupled inverter.
 
@@ -1147,7 +1150,7 @@ class GrowattApi:
         return self.update_inverter_setting(serial_number, setting_type,
                                             default_parameters, parameters)
 
-    def update_tlx_inverter_time_segment(self, serial_number, segment_id, batt_mode, start_time, end_time, enabled):
+    def update_tlx_inverter_time_segment(self, serial_number: str, segment_id: int, batt_mode: int, start_time: datetime.time, end_time: datetime.time, enabled: bool) -> dict[str, Any]:
         """
         Update a TLX inverter time segment.
 
@@ -1187,7 +1190,7 @@ class GrowattApi:
 
         return result
 
-    def update_tlx_inverter_setting(self, serial_number, setting_type, parameter):
+    def update_tlx_inverter_setting(self, serial_number: str, setting_type: str, parameter: dict[str, Any] | list[Any] | str) -> dict[str, Any]:
         """
         Set parameters on a TLX inverter.
 
@@ -1216,7 +1219,7 @@ class GrowattApi:
         return self.update_inverter_setting(serial_number, setting_type,
                                             default_parameters, parameter)
 
-    def update_noah_settings(self, serial_number, setting_type, parameters):
+    def update_noah_settings(self, serial_number: str, setting_type: str, parameters: dict[str, Any] | list[Any]) -> dict[str, Any]:
         """
         Apply settings for a Noah device.
 
@@ -1248,7 +1251,7 @@ class GrowattApi:
 
         return response.json()
 
-    def classic_inverter_info(self, device_sn):
+    def classic_inverter_info(self, device_sn: str) -> dict[str, Any]:
         """
         Get classic inverter information by scraping the inverter settings page.
 
@@ -1311,7 +1314,7 @@ class GrowattApi:
             msg = f"Failed to parse inverter data JSON for device {device_sn}"
             raise GrowattError(msg) from err
 
-    def update_classic_inverter_setting(self, default_parameters, parameters):
+    def update_classic_inverter_setting(self, default_parameters: dict[str, Any], parameters: dict[str, Any] | list[Any]) -> dict[str, Any]:
         """
         Apply classic inverter settings.
 

--- a/growattServer/exceptions.py
+++ b/growattServer/exceptions.py
@@ -13,6 +13,8 @@ Common requests exceptions to handle:
 - requests.exceptions.RequestException: The base exception for all requests exceptions
 """
 
+from __future__ import annotations
+
 from enum import IntEnum
 
 

--- a/growattServer/open_api_v1/__init__.py
+++ b/growattServer/open_api_v1/__init__.py
@@ -11,7 +11,7 @@ from typing import Any
 from growattServer import GrowattApi
 from growattServer.exceptions import GrowattV1ApiError
 
-from .devices import AbstractDevice, Min, Sph
+from .devices import AbstractDevice, Min, ParameterValue, Sph
 
 
 class DeviceType(Enum):
@@ -487,7 +487,7 @@ class OpenApiV1(GrowattApi):
             parameter_id, start_address, end_address
         )
 
-    def min_write_parameter(self, device_sn: str, parameter_id: str, parameter_values: str | float | bool | list[Any] | dict[str, Any] | None = None) -> dict[str, Any]:
+    def min_write_parameter(self, device_sn: str, parameter_id: str, parameter_values: ParameterValue | None = None) -> dict[str, Any]:
         """
         Set parameters on a MIN inverter.
 
@@ -670,7 +670,7 @@ class OpenApiV1(GrowattApi):
             parameter_id, start_address, end_address
         )
 
-    def sph_write_parameter(self, device_sn: str, parameter_id: str, parameter_values: str | float | bool | list[Any] | dict[str, Any] | None = None) -> dict[str, Any]:
+    def sph_write_parameter(self, device_sn: str, parameter_id: str, parameter_values: ParameterValue | None = None) -> dict[str, Any]:
         """
         Set parameters on an SPH inverter.
 

--- a/growattServer/open_api_v1/__init__.py
+++ b/growattServer/open_api_v1/__init__.py
@@ -1,9 +1,12 @@
 """OpenApi V1 extensions for Growatt API client."""
 
+from __future__ import annotations
+
 import platform
 import warnings
-from datetime import UTC, date, datetime
+from datetime import UTC, date, datetime, time
 from enum import Enum
+from typing import Any
 
 from growattServer import GrowattApi
 from growattServer.exceptions import GrowattV1ApiError
@@ -42,7 +45,7 @@ class OpenApiV1(GrowattApi):
 
         return f"Python/{python_version} ({system} {release}; {machine})"
 
-    def __init__(self, token) -> None:
+    def __init__(self, token: str) -> None:
         """
         Initialize the Growatt API client with V1 API support.
 
@@ -59,7 +62,7 @@ class OpenApiV1(GrowattApi):
         # Set up authentication for V1 API using the provided token
         self.session.headers.update({"token": token})
 
-    def process_response(self, response, operation_name="API operation"):
+    def process_response(self, response: dict[str, Any], operation_name: str = "API operation") -> dict[str, Any]:
         """
         Process API response and handle errors.
 
@@ -83,11 +86,11 @@ class OpenApiV1(GrowattApi):
             )
         return response.get("data")
 
-    def get_url(self, page):
+    def get_url(self, page: str) -> str:
         """Return the page URL for the v1 API."""
         return self.api_url + page
 
-    def plant_list(self):
+    def plant_list(self) -> dict[str, Any]:
         """
         Get a list of all plants with detailed information.
 
@@ -116,7 +119,7 @@ class OpenApiV1(GrowattApi):
 
         return self.process_response(response.json(), "getting plant list")
 
-    def plant_details(self, plant_id):
+    def plant_details(self, plant_id: int) -> dict[str, Any]:
         """
         Get basic information about a power station.
 
@@ -144,7 +147,7 @@ class OpenApiV1(GrowattApi):
 
         return self.process_response(response.json(), "getting plant details")
 
-    def plant_energy_overview(self, plant_id):
+    def plant_energy_overview(self, plant_id: int) -> dict[str, Any]:
         """
         Get an overview of a plant's energy data.
 
@@ -220,13 +223,13 @@ class OpenApiV1(GrowattApi):
 
     def plant_energy_history(
         self,
-        plant_id,
-        start_date=None,
-        end_date=None,
-        time_unit="day",
-        page=None,
-        perpage=None,
-    ):
+        plant_id: int,
+        start_date: date | None = None,
+        end_date: date | None = None,
+        time_unit: str = "day",
+        page: int | None = None,
+        perpage: int | None = None,
+    ) -> dict[str, Any]:
         """
         Retrieve plant energy data for multiple days/months/years.
 
@@ -306,7 +309,7 @@ class OpenApiV1(GrowattApi):
 
         return self.process_response(response.json(), "getting plant energy history")
 
-    def device_list(self, plant_id):
+    def device_list(self, plant_id: int) -> dict[str, Any]:
         """
         Get devices associated with plant.
 
@@ -375,7 +378,7 @@ class OpenApiV1(GrowattApi):
                 )
                 return None
 
-    def min_detail(self, device_sn):
+    def min_detail(self, device_sn: str) -> dict[str, Any]:
         """
         Get detailed data for a MIN inverter.
 
@@ -392,7 +395,7 @@ class OpenApiV1(GrowattApi):
         """
         return Min(self, device_sn).detail()
 
-    def min_energy(self, device_sn):
+    def min_energy(self, device_sn: str) -> dict[str, Any]:
         """
         Get energy data for a MIN inverter.
 
@@ -411,13 +414,13 @@ class OpenApiV1(GrowattApi):
 
     def min_energy_history(
         self,
-        device_sn,
-        start_date=None,
-        end_date=None,
-        timezone=None,
-        page=None,
-        limit=None,
-    ):
+        device_sn: str,
+        start_date: date | None = None,
+        end_date: date | None = None,
+        timezone: str | None = None,
+        page: int | None = None,
+        limit: int | None = None,
+    ) -> dict[str, Any]:
         """
         Get MIN inverter data history.
 
@@ -442,7 +445,7 @@ class OpenApiV1(GrowattApi):
             start_date, end_date, timezone, page, limit
         )
 
-    def min_settings(self, device_sn):
+    def min_settings(self, device_sn: str) -> dict[str, Any]:
         """
         Get settings for a MIN inverter.
 
@@ -460,8 +463,8 @@ class OpenApiV1(GrowattApi):
         return Min(self, device_sn).settings()
 
     def min_read_parameter(
-        self, device_sn, parameter_id, start_address=None, end_address=None
-    ):
+        self, device_sn: str, parameter_id: str, start_address: int | None = None, end_address: int | None = None
+    ) -> dict[str, Any]:
         """
         Read setting from MIN inverter.
 
@@ -484,7 +487,7 @@ class OpenApiV1(GrowattApi):
             parameter_id, start_address, end_address
         )
 
-    def min_write_parameter(self, device_sn, parameter_id, parameter_values=None):
+    def min_write_parameter(self, device_sn: str, parameter_id: str, parameter_values: str | float | bool | list[Any] | dict[str, Any] | None = None) -> dict[str, Any]:
         """
         Set parameters on a MIN inverter.
 
@@ -507,8 +510,8 @@ class OpenApiV1(GrowattApi):
         return Min(self, device_sn).write_parameter(parameter_id, parameter_values)
 
     def min_write_time_segment(
-        self, device_sn, segment_id, batt_mode, start_time, end_time, enabled=True
-    ):
+        self, device_sn: str, segment_id: int, batt_mode: int, start_time: time, end_time: time, enabled: bool = True
+    ) -> dict[str, Any]:
         """
         Set a time segment for a MIN inverter.
 
@@ -533,7 +536,7 @@ class OpenApiV1(GrowattApi):
             segment_id, batt_mode, start_time, end_time, enabled
         )
 
-    def min_read_time_segments(self, device_sn, settings_data=None):
+    def min_read_time_segments(self, device_sn: str, settings_data: dict[str, Any] | None = None) -> list[dict[str, Any]]:
         """
         Read Time-of-Use (TOU) settings from a Growatt MIN/TLX inverter.
 
@@ -575,7 +578,7 @@ class OpenApiV1(GrowattApi):
 
     # SPH Device Methods (Device Type 5)
 
-    def sph_detail(self, device_sn):
+    def sph_detail(self, device_sn: str) -> dict[str, Any]:
         """
         Get detailed data for an SPH inverter.
 
@@ -592,7 +595,7 @@ class OpenApiV1(GrowattApi):
         """
         return Sph(self, device_sn).detail()
 
-    def sph_energy(self, device_sn):
+    def sph_energy(self, device_sn: str) -> dict[str, Any]:
         """
         Get energy data for an SPH inverter.
 
@@ -611,13 +614,13 @@ class OpenApiV1(GrowattApi):
 
     def sph_energy_history(
         self,
-        device_sn,
-        start_date=None,
-        end_date=None,
-        timezone=None,
-        page=None,
-        limit=None,
-    ):
+        device_sn: str,
+        start_date: date | None = None,
+        end_date: date | None = None,
+        timezone: str | None = None,
+        page: int | None = None,
+        limit: int | None = None,
+    ) -> dict[str, Any]:
         """
         Get SPH inverter data history.
 
@@ -643,8 +646,8 @@ class OpenApiV1(GrowattApi):
         )
 
     def sph_read_parameter(
-        self, device_sn, parameter_id=None, start_address=None, end_address=None
-    ):
+        self, device_sn: str, parameter_id: str | None = None, start_address: int | None = None, end_address: int | None = None
+    ) -> dict[str, Any]:
         """
         Read setting from SPH inverter.
 
@@ -667,7 +670,7 @@ class OpenApiV1(GrowattApi):
             parameter_id, start_address, end_address
         )
 
-    def sph_write_parameter(self, device_sn, parameter_id, parameter_values=None):
+    def sph_write_parameter(self, device_sn: str, parameter_id: str, parameter_values: str | float | bool | list[Any] | dict[str, Any] | None = None) -> dict[str, Any]:
         """
         Set parameters on an SPH inverter.
 
@@ -690,8 +693,8 @@ class OpenApiV1(GrowattApi):
         return Sph(self, device_sn).write_parameter(parameter_id, parameter_values)
 
     def sph_write_ac_charge_times(
-        self, device_sn, charge_power, charge_stop_soc, mains_enabled, periods
-    ):
+        self, device_sn: str, charge_power: int, charge_stop_soc: int, mains_enabled: bool, periods: list[dict[str, Any]]
+    ) -> dict[str, Any]:
         """
         Set AC charge time periods for an SPH inverter.
 
@@ -734,8 +737,8 @@ class OpenApiV1(GrowattApi):
         )
 
     def sph_write_ac_discharge_times(
-        self, device_sn, discharge_power, discharge_stop_soc, periods
-    ):
+        self, device_sn: str, discharge_power: int, discharge_stop_soc: int, periods: list[dict[str, Any]]
+    ) -> dict[str, Any]:
         """
         Set AC discharge time periods for an SPH inverter.
 
@@ -775,7 +778,7 @@ class OpenApiV1(GrowattApi):
             discharge_power, discharge_stop_soc, periods
         )
 
-    def sph_read_ac_charge_times(self, device_sn, settings_data=None):
+    def sph_read_ac_charge_times(self, device_sn: str, settings_data: dict[str, Any] | None = None) -> dict[str, Any]:
         """
         Read AC charge time periods and settings from an SPH inverter.
 
@@ -819,7 +822,7 @@ class OpenApiV1(GrowattApi):
         """
         return Sph(self, device_sn).read_ac_charge_times(settings_data)
 
-    def sph_read_ac_discharge_times(self, device_sn, settings_data=None):
+    def sph_read_ac_discharge_times(self, device_sn: str, settings_data: dict[str, Any] | None = None) -> dict[str, Any]:
         """
         Read AC discharge time periods and settings from an SPH inverter.
 

--- a/growattServer/open_api_v1/devices/__init__.py
+++ b/growattServer/open_api_v1/devices/__init__.py
@@ -1,6 +1,6 @@
 # noqa: D104
 from __future__ import annotations
 
-from .abstract_device import AbstractDevice  # noqa: F401
+from .abstract_device import AbstractDevice, ParameterValue  # noqa: F401
 from .min import Min  # noqa: F401
 from .sph import Sph  # noqa: F401

--- a/growattServer/open_api_v1/devices/__init__.py
+++ b/growattServer/open_api_v1/devices/__init__.py
@@ -1,4 +1,6 @@
 # noqa: D104
+from __future__ import annotations
+
 from .abstract_device import AbstractDevice  # noqa: F401
 from .min import Min  # noqa: F401
 from .sph import Sph  # noqa: F401

--- a/growattServer/open_api_v1/devices/abstract_device.py
+++ b/growattServer/open_api_v1/devices/abstract_device.py
@@ -1,4 +1,7 @@
 """Abstract device file for centralising shared device logic."""
+
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, TypedDict
 
 from growattServer.exceptions import GrowattParameterError
@@ -17,7 +20,7 @@ class ReadParamResponse(TypedDict):
 class AbstractDevice:
     """Abstract device type. Must not be used directly."""
 
-    def __init__(self, api: "OpenApiV1", device_sn: str) -> None:
+    def __init__(self, api: OpenApiV1, device_sn: str) -> None:
         """
         Initialize the device with the bare minimum being the device_sn.
 
@@ -29,7 +32,7 @@ class AbstractDevice:
         self.api = api
         self.device_sn = device_sn
 
-    def validate_read_parameter_input(self, parameter_id: str | None, start_address: int | None, end_address: int | None): # noqa: ARG002
+    def validate_read_parameter_input(self, parameter_id: str | None, start_address: int | None, end_address: int | None) -> None: # noqa: ARG002
         """
         Validate read parameter input and throws an error if it is invalid.
 

--- a/growattServer/open_api_v1/devices/abstract_device.py
+++ b/growattServer/open_api_v1/devices/abstract_device.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, TypedDict
+from typing import TYPE_CHECKING, Any, TypedDict
 
 from growattServer.exceptions import GrowattParameterError
 
 if TYPE_CHECKING:
     from growattServer.open_api_v1 import OpenApiV1
+
+
+type ParameterValue = str | float | bool | list[Any] | dict[str, Any]
 
 
 class ReadParamResponse(TypedDict):

--- a/growattServer/open_api_v1/devices/min.py
+++ b/growattServer/open_api_v1/devices/min.py
@@ -7,7 +7,7 @@ from typing import Any
 
 from growattServer.exceptions import GrowattParameterError
 
-from .abstract_device import AbstractDevice
+from .abstract_device import AbstractDevice, ParameterValue
 
 
 class Min(AbstractDevice):
@@ -213,7 +213,7 @@ class Min(AbstractDevice):
             response.json(), f"reading parameter {parameter_id}"
         )
 
-    def write_parameter(self, parameter_id: str, parameter_values: str | float | bool | list[Any] | dict[str, Any] | None = None) -> dict[str, Any]:
+    def write_parameter(self, parameter_id: str, parameter_values: ParameterValue | None = None) -> dict[str, Any]:
         """
         Set parameters on a MIN inverter.
 

--- a/growattServer/open_api_v1/devices/min.py
+++ b/growattServer/open_api_v1/devices/min.py
@@ -1,6 +1,8 @@
 """Min/TLX device file."""
 
-from datetime import UTC, datetime, timedelta
+from __future__ import annotations
+
+from datetime import UTC, date, datetime, time, timedelta
 from typing import Any
 
 from growattServer.exceptions import GrowattParameterError
@@ -13,7 +15,7 @@ class Min(AbstractDevice):
 
     DEVICE_TYPE_ID = 7
 
-    def detail(self) -> dict:
+    def detail(self) -> dict[str, Any]:
         """
         Get detailed data for a MIN inverter.
 
@@ -38,7 +40,7 @@ class Min(AbstractDevice):
             response.json(), "getting MIN inverter details"
         )
 
-    def energy(self) -> dict:
+    def energy(self) -> dict[str, Any]:
         """
         Get energy data for a MIN inverter.
 
@@ -68,8 +70,8 @@ class Min(AbstractDevice):
         )
 
     def energy_history(
-        self, start_date=None, end_date=None, timezone=None, page=None, limit=None
-    ) -> dict:
+        self, start_date: date | None = None, end_date: date | None = None, timezone: str | None = None, page: int | None = None, limit: int | None = None
+    ) -> dict[str, Any]:
         """
         Get MIN inverter data history.
 
@@ -127,7 +129,7 @@ class Min(AbstractDevice):
             response.json(), "getting MIN inverter energy history"
         )
 
-    def settings(self) -> dict:
+    def settings(self) -> dict[str, Any]:
         """
         Get settings for a MIN inverter.
 
@@ -152,8 +154,8 @@ class Min(AbstractDevice):
         )
 
     def read_parameter(
-        self, parameter_id, start_address=None, end_address=None
-    ) -> dict:
+        self, parameter_id: str, start_address: int | None = None, end_address: int | None = None
+    ) -> dict[str, Any]:
         """
         Read setting from MIN inverter.
 
@@ -211,7 +213,7 @@ class Min(AbstractDevice):
             response.json(), f"reading parameter {parameter_id}"
         )
 
-    def write_parameter(self, parameter_id, parameter_values=None) -> dict:
+    def write_parameter(self, parameter_id: str, parameter_values: str | float | bool | list[Any] | dict[str, Any] | None = None) -> dict[str, Any]:
         """
         Set parameters on a MIN inverter.
 
@@ -280,8 +282,8 @@ class Min(AbstractDevice):
         )
 
     def write_time_segment(
-        self, segment_id, batt_mode, start_time, end_time, enabled=True
-    ) -> dict:
+        self, segment_id: int, batt_mode: int, start_time: time, end_time: time, enabled: bool = True
+    ) -> dict[str, Any]:
         """
         Set a time segment for a MIN inverter.
 
@@ -349,7 +351,7 @@ class Min(AbstractDevice):
             response.json(), f"writing time segment {segment_id}"
         )
 
-    def read_time_segments(self, settings_data=None) -> list[dict[str, Any]]:
+    def read_time_segments(self, settings_data: dict[str, Any] | None = None) -> list[dict[str, Any]]:
         """
         Read Time-of-Use (TOU) settings from a Growatt MIN/TLX inverter.
 

--- a/growattServer/open_api_v1/devices/sph.py
+++ b/growattServer/open_api_v1/devices/sph.py
@@ -7,7 +7,7 @@ from typing import Any
 
 from growattServer.exceptions import GrowattParameterError
 
-from .abstract_device import AbstractDevice
+from .abstract_device import AbstractDevice, ParameterValue
 
 
 class Sph(AbstractDevice):
@@ -189,7 +189,7 @@ class Sph(AbstractDevice):
             response.json(), f"reading parameter {parameter_id}"
         )
 
-    def write_parameter(self, parameter_id: str, parameter_values: str | float | bool | list[Any] | dict[str, Any] | None = None) -> dict[str, Any]:
+    def write_parameter(self, parameter_id: str, parameter_values: ParameterValue | None = None) -> dict[str, Any]:
         """
         Set parameters on an SPH inverter.
 

--- a/growattServer/open_api_v1/devices/sph.py
+++ b/growattServer/open_api_v1/devices/sph.py
@@ -1,6 +1,9 @@
 """SPH/MIX device file."""
 
-from datetime import UTC, datetime, timedelta
+from __future__ import annotations
+
+from datetime import UTC, date, datetime, timedelta
+from typing import Any
 
 from growattServer.exceptions import GrowattParameterError
 
@@ -12,7 +15,7 @@ class Sph(AbstractDevice):
 
     DEVICE_TYPE_ID = 5
 
-    def detail(self):
+    def detail(self) -> dict[str, Any]:
         """
         Get detailed data for an SPH inverter.
 
@@ -37,7 +40,7 @@ class Sph(AbstractDevice):
             response.json(), "getting SPH inverter details"
         )
 
-    def energy(self):
+    def energy(self) -> dict[str, Any]:
         """
         Get energy data for an SPH inverter.
 
@@ -67,8 +70,8 @@ class Sph(AbstractDevice):
         )
 
     def energy_history(
-        self, start_date=None, end_date=None, timezone=None, page=None, limit=None
-    ):
+        self, start_date: date | None = None, end_date: date | None = None, timezone: str | None = None, page: int | None = None, limit: int | None = None
+    ) -> dict[str, Any]:
         """
         Get SPH inverter data history.
 
@@ -125,7 +128,7 @@ class Sph(AbstractDevice):
             response.json(), "getting SPH inverter energy history"
         )
 
-    def read_parameter(self, parameter_id=None, start_address=None, end_address=None):
+    def read_parameter(self, parameter_id: str | None = None, start_address: int | None = None, end_address: int | None = None) -> dict[str, Any]:
         """
         Read setting from SPH inverter.
 
@@ -186,7 +189,7 @@ class Sph(AbstractDevice):
             response.json(), f"reading parameter {parameter_id}"
         )
 
-    def write_parameter(self, parameter_id, parameter_values=None):
+    def write_parameter(self, parameter_id: str, parameter_values: str | float | bool | list[Any] | dict[str, Any] | None = None) -> dict[str, Any]:
         """
         Set parameters on an SPH inverter.
 
@@ -254,8 +257,8 @@ class Sph(AbstractDevice):
         )
 
     def write_ac_charge_times(
-        self, charge_power, charge_stop_soc, mains_enabled, periods
-    ):
+        self, charge_power: int, charge_stop_soc: int, mains_enabled: bool, periods: list[dict[str, Any]]
+    ) -> dict[str, Any]:
         """
         Set AC charge time periods for an SPH inverter.
 
@@ -342,7 +345,7 @@ class Sph(AbstractDevice):
             response.json(), "writing AC charge time periods"
         )
 
-    def write_ac_discharge_times(self, discharge_power, discharge_stop_soc, periods):
+    def write_ac_discharge_times(self, discharge_power: int, discharge_stop_soc: int, periods: list[dict[str, Any]]) -> dict[str, Any]:
         """
         Set AC discharge time periods for an SPH inverter.
 
@@ -426,7 +429,7 @@ class Sph(AbstractDevice):
             response.json(), "writing AC discharge time periods"
         )
 
-    def _parse_time_periods(self, settings_data, time_type):
+    def _parse_time_periods(self, settings_data: dict[str, Any], time_type: str) -> list[dict[str, Any]]:
         """
         Parse time periods from settings data.
 
@@ -496,7 +499,7 @@ class Sph(AbstractDevice):
 
         return periods
 
-    def read_ac_charge_times(self, settings_data=None):
+    def read_ac_charge_times(self, settings_data: dict[str, Any] | None = None) -> dict[str, Any]:
         """
         Read AC charge time periods and settings from an SPH inverter.
 
@@ -571,7 +574,7 @@ class Sph(AbstractDevice):
             "periods": self._parse_time_periods(settings_data, "Charge"),
         }
 
-    def read_ac_discharge_times(self, settings_data=None):
+    def read_ac_discharge_times(self, settings_data: dict[str, Any] | None = None) -> dict[str, Any]:
         """
         Read AC discharge time periods and settings from an SPH inverter.
 

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/indykoning/PyPi_GrowattServer",
     packages=setuptools.find_packages(),
+    package_data={"growattServer": ["py.typed"]},
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
## Summary

Adds PEP 561 typing support so that type checkers (mypy, pyright) can validate code that uses this library. Without this, callers get `Any` for every function call — typos in parameter names, wrong argument types, and missing required arguments are only caught at runtime when the Growatt API returns an error (or silently does the wrong thing).

**What this enables:**
- Type checkers can now catch bugs like `api.login(username=123, password=pwd)` or `api.plant_detail(plant_id, "invalid")` at development time
- IDE autocompletion now shows correct parameter names, types, and return types
- Downstream projects (e.g. Home Assistant integrations) that run strict type checking can use this library without `type: ignore` suppressions

**Changes:**
- Add `py.typed` marker file and include it in package data
- Add `from __future__ import annotations` to all modules
- Add type annotations to all public functions (~100 signatures across 7 files)
- Extract `ParameterValue` type alias for the recurring write parameter union type
- Add `FBT001` to ruff ignore list (boolean positional args are part of the existing public API)

**Risk:** Zero logic changes. Every diff line is either an import or a function signature annotation. With `from __future__ import annotations`, annotations are stored as strings and never evaluated at runtime — the package behaves identically to before.

## Test plan
- [x] All package imports verified working
- [x] `ruff check` passes clean
- [x] Diff audited: confirmed zero logic changes, only annotations and imports

🤖 Generated with [Claude Code](https://claude.com/claude-code)