### PR TITLE
Fix mypy type errors exposed by py.typed marker

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -1,0 +1,15 @@
+name: mypy
+on:
+  - push
+  - pull_request
+
+jobs:
+  mypy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install mypy types-requests
+      - run: mypy --ignore-missing-imports growattServer/

--- a/growattServer/base_api.py
+++ b/growattServer/base_api.py
@@ -76,7 +76,7 @@ class GrowattApi:
             _ = kwargs
             response.raise_for_status()
 
-        self.session.hooks = {"response": _raise_for_status}
+        self.session.hooks = {"response": [_raise_for_status]}
 
         headers = {"User-Agent": self.agent_identifier}
         self.session.headers.update(headers)
@@ -266,12 +266,13 @@ class GrowattApi:
 
         """
         date_str = self.__get_date_string(date=date)
-        response = self.session.get(self.get_url("newInverterAPI.do"), params={
+        params: dict[str, str | int] = {
             "op": "getInverterData",
             "id": inverter_id,
             "type": 1,
-            "date": date_str
-        })
+            "date": date_str,
+        }
+        response = self.session.get(self.get_url("newInverterAPI.do"), params=params)
 
         return response.json()
 
@@ -412,12 +413,13 @@ class GrowattApi:
 
         """
         date_str = self.__get_date_string(date=date)
-        response = self.session.get(self.get_url("newTlxApi.do"), params={
+        params: dict[str, str | int] = {
             "op": "getTlxData",
             "id": tlx_id,
             "type": 1,
-            "date": date_str
-        })
+            "date": date_str,
+        }
+        response = self.session.get(self.get_url("newTlxApi.do"), params=params)
 
         return response.json()
 
@@ -753,10 +755,10 @@ class GrowattApi:
             dict: A dictionary of settings.
 
         """
-        default_params = {
+        default_params: dict[str, str | int] = {
             "op": "getMixSetParams",
             "serialNum": serial_number,
-            "kind": 0
+            "kind": 0,
         }
         response = self.session.get(self.get_url("newMixApi.do"), params=default_params)
         return response.json()
@@ -870,10 +872,12 @@ class GrowattApi:
 
     def __get_all_devices(self, plant_id: str) -> dict[str, Any]:
         """Get basic plant information with device list."""
-        response = self.session.get(self.get_url("newTwoPlantAPI.do"),
-                                    params={"op": "getAllDeviceList",
-                                            "plantId": plant_id,
-                                            "language": 1})
+        params: dict[str, str | int] = {
+            "op": "getAllDeviceList",
+            "plantId": plant_id,
+            "language": 1,
+        }
+        response = self.session.get(self.get_url("newTwoPlantAPI.do"), params=params)
 
         return response.json().get("deviceList", {})
 
@@ -889,12 +893,13 @@ class GrowattApi:
 
     def plant_info(self, plant_id: str) -> dict[str, Any]:
         """Get basic plant information with device list."""
-        response = self.session.get(self.get_url("newTwoPlantAPI.do"), params={
+        params: dict[str, str | int] = {
             "op": "getAllDeviceListTwo",
             "plantId": plant_id,
             "pageNum": 1,
-            "pageSize": 1
-        })
+            "pageSize": 1,
+        }
+        response = self.session.get(self.get_url("newTwoPlantAPI.do"), params=params)
 
         return response.json()
 
@@ -1093,18 +1098,19 @@ class GrowattApi:
         # Ensure declared but unused args are referenced to satisfy linters
         _ = serial_number
         _ = setting_type
-        settings_parameters = parameters
 
         # If we've been passed an array then convert it into a dictionary
         if isinstance(parameters, list):
-            settings_parameters = {}
+            settings_parameters: dict[str, Any] = {}
             for index, param in enumerate(parameters, start=1):
                 settings_parameters["param" + str(index)] = param
+        else:
+            settings_parameters = parameters
 
-        settings_parameters = {**default_parameters, **settings_parameters}
+        merged = {**default_parameters, **settings_parameters}
 
         response = self.session.post(self.get_url("newTcpsetAPI.do"),
-                                     params=settings_parameters)
+                                     params=merged)
 
         return response.json()
 
@@ -1234,20 +1240,21 @@ class GrowattApi:
         """
         default_parameters = {
             "serialNum": serial_number,
-            "type": setting_type
+            "type": setting_type,
         }
-        settings_parameters = parameters
 
         # If we've been passed an array then convert it into a dictionary
         if isinstance(parameters, list):
-            settings_parameters = {}
+            settings_parameters: dict[str, Any] = {}
             for index, param in enumerate(parameters, start=1):
                 settings_parameters["param" + str(index)] = param
+        else:
+            settings_parameters = parameters
 
-        settings_parameters = {**default_parameters, **settings_parameters}
+        merged = {**default_parameters, **settings_parameters}
 
         response = self.session.post(self.get_url("noahDeviceApi/noah/set"),
-                                     data=settings_parameters)
+                                     data=merged)
 
         return response.json()
 
@@ -1391,13 +1398,13 @@ class GrowattApi:
             dict: Server JSON response.
 
         """
-        settings_parameters = parameters
-
         # If we've been passed an array then convert it into a dictionary
         if isinstance(parameters, list):
-            settings_parameters = {}
+            settings_parameters: dict[str, Any] = {}
             for index, param in enumerate(parameters, start=1):
                 settings_parameters["param" + str(index)] = param
+        else:
+            settings_parameters = parameters
 
         settings_parameters = {**default_parameters, **settings_parameters}
 

--- a/growattServer/open_api_v1/__init__.py
+++ b/growattServer/open_api_v1/__init__.py
@@ -62,7 +62,7 @@ class OpenApiV1(GrowattApi):
         # Set up authentication for V1 API using the provided token
         self.session.headers.update({"token": token})
 
-    def process_response(self, response: dict[str, Any], operation_name: str = "API operation") -> dict[str, Any]:
+    def process_response(self, response: dict[str, Any], operation_name: str = "API operation") -> Any:
         """
         Process API response and handle errors.
 
@@ -90,7 +90,7 @@ class OpenApiV1(GrowattApi):
         """Return the page URL for the v1 API."""
         return self.api_url + page
 
-    def plant_list(self) -> dict[str, Any]:
+    def plant_list(self) -> dict[str, Any]:  # type: ignore[override]
         """
         Get a list of all plants with detailed information.
 
@@ -211,12 +211,13 @@ class OpenApiV1(GrowattApi):
         if day is None:
             day = datetime.now(tz=UTC).astimezone().date()
 
+        params: dict[str, str | int] = {
+            "plant_id": plant_id,
+            "date": str(day),
+        }
         response = self.session.get(
             self.get_url("plant/power"),
-            params={
-                "plant_id": plant_id,
-                "date": day,
-            },
+            params=params,
         )
 
         return self.process_response(response.json(), "getting plant power overview")
@@ -265,12 +266,10 @@ class OpenApiV1(GrowattApi):
         max_day_interval = 7
         max_year_interval = 20
 
-        if start_date is None and end_date is None:
-            start_date = datetime.now(tz=UTC).astimezone().date()
-            end_date = datetime.now(tz=UTC).astimezone().date()
-        elif start_date is None:
-            start_date = end_date
-        elif end_date is None:
+        today = datetime.now(tz=UTC).astimezone().date()
+        if start_date is None:
+            start_date = end_date if end_date is not None else today
+        if end_date is None:
             end_date = start_date
 
         # Validate date ranges based on time_unit
@@ -309,7 +308,7 @@ class OpenApiV1(GrowattApi):
 
         return self.process_response(response.json(), "getting plant energy history")
 
-    def device_list(self, plant_id: int) -> dict[str, Any]:
+    def device_list(self, plant_id: int) -> dict[str, Any]:  # type: ignore[override]
         """
         Get devices associated with plant.
 
@@ -354,13 +353,14 @@ class OpenApiV1(GrowattApi):
             }
 
         """
+        params: dict[str, str | int] = {
+            "plant_id": plant_id,
+            "page": "",
+            "perpage": "",
+        }
         response = self.session.get(
             url=self.get_url("device/list"),
-            params={
-                "plant_id": plant_id,
-                "page": "",
-                "perpage": "",
-            },
+            params=params,
         )
         return self.process_response(response.json(), "getting device list")
 

--- a/growattServer/open_api_v1/devices/min.py
+++ b/growattServer/open_api_v1/devices/min.py
@@ -101,12 +101,10 @@ class Min(AbstractDevice):
             https://www.showdoc.com.cn/262556420217021/6129764475556048
 
         """
-        if start_date is None and end_date is None:
-            start_date = datetime.now(tz=UTC).astimezone().date()
-            end_date = datetime.now(tz=UTC).astimezone().date()
-        elif start_date is None:
-            start_date = end_date
-        elif end_date is None:
+        today = datetime.now(tz=UTC).astimezone().date()
+        if start_date is None:
+            start_date = end_date if end_date is not None else today
+        if end_date is None:
             end_date = start_date
 
         # check interval validity
@@ -451,7 +449,7 @@ class Min(AbstractDevice):
             segment = {
                 "segment_id": i,
                 "batt_mode": batt_mode,
-                "mode_name": mode_names.get(batt_mode, "Unknown"),
+                "mode_name": mode_names.get(batt_mode, "Unknown") if batt_mode is not None else "Unknown",
                 "start_time": start_time,
                 "end_time": end_time,
                 "enabled": enabled,

--- a/growattServer/open_api_v1/devices/sph.py
+++ b/growattServer/open_api_v1/devices/sph.py
@@ -100,12 +100,10 @@ class Sph(AbstractDevice):
             https://www.showdoc.com.cn/262556420217021/6129765461123058
 
         """
-        if start_date is None and end_date is None:
-            start_date = datetime.now(tz=UTC).astimezone().date()
-            end_date = datetime.now(tz=UTC).astimezone().date()
-        elif start_date is None:
-            start_date = end_date
-        elif end_date is None:
+        today = datetime.now(tz=UTC).astimezone().date()
+        if start_date is None:
+            start_date = end_date if end_date is not None else today
+        if end_date is None:
             end_date = start_date
 
         # check interval validity


### PR DESCRIPTION
## Summary

- Fixes all 30 mypy type errors that consumers would encounter now that `py.typed` is shipped (#147)
- Adds a mypy CI workflow to prevent type regressions going forward
- No behavioral changes — all fixes are annotations, type narrowing, and structural improvements

### What was fixed

| Category | Count | Fix |
|---|---|---|
| `dict[str, object]` inference in params dicts | 8 | Explicit `dict[str, str \| int]` annotations |
| `union-attr` / `operator` on Optional dates | 8 | Simplified None-narrowing with sequential `if` |
| `dict-item` in dict unpacking with union types | 3 | Proper `isinstance` narrowing with `else` branch |
| `override` (V1 API intentionally changes signatures) | 3 | `# type: ignore[override]` |
| `dict-item` for session hooks | 1 | Wrap hook function in list |
| `return-value` for `process_response` | 1 | Return type `Any` (`.get()` can return `None`) |
| `arg-type` for `mode_names.get(None)` | 1 | Guard against `None` key |

### CI workflow

Added `.github/workflows/mypy.yml` — runs `mypy --ignore-missing-imports` on every push and PR, matching the existing ruff workflow. This ensures the `py.typed` marker remains meaningful by keeping the package mypy-clean.

### Why this matters

PR #147 added the PEP 561 `py.typed` marker, which signals to type checkers that this package ships type hints. Without clean types, consumers running mypy see errors *from inside the library* that they cannot fix — arguably worse than not shipping `py.typed` at all.

## Test plan
- [x] `mypy --ignore-missing-imports` passes with 0 errors (was 30)
- [x] `ruff check` passes
- [x] Runtime smoke test — all imports, instantiation, and hash_password work correctly
- [x] No public API changes — all fixes are internal

🤖 Generated with [Claude Code](https://claude.com/claude-code)
