### PR TITLE
Fixed incorrect return type annotations in base_api

### DIFF
--- a/growattServer/base_api.py
+++ b/growattServer/base_api.py
@@ -868,14 +868,14 @@ class GrowattApi:
             "This function may be deprecated in the future because naming is not correct, use device_list instead", DeprecationWarning, stacklevel=2)
         return self.device_list(plant_id)
 
-    def __get_all_devices(self, plant_id: str) -> dict[str, Any]:
+    def __get_all_devices(self, plant_id: str) -> list[dict[str, Any]]:
         """Get basic plant information with device list."""
         response = self.session.get(self.get_url("newTwoPlantAPI.do"),
                                     params={"op": "getAllDeviceList",
                                             "plantId": plant_id,
                                             "language": 1})
 
-        return response.json().get("deviceList", {})
+        return response.json().get("deviceList", [])
 
     def device_list(self, plant_id: str) -> list[dict[str, Any]]:
         """Get a list of all devices connected to plant."""

--- a/growattServer/base_api.py
+++ b/growattServer/base_api.py
@@ -178,7 +178,7 @@ class GrowattApi:
             })
         return data
 
-    def plant_list(self, user_id: str) -> list[dict[str, Any]]:
+    def plant_list(self, user_id: str) -> dict[str, Any]:
         """
         Get a list of plants connected to this account.
 
@@ -186,7 +186,7 @@ class GrowattApi:
             user_id (str): The ID of the user.
 
         Returns:
-            list: A list of plants connected to the account.
+            dict: A dictionary containing 'data' (list of plants) and 'totalData' keys.
 
         Raises:
             Exception: If the request to the server fails.


### PR DESCRIPTION
## Summary
- Fix `plant_list` return type from `list[dict[str, Any]]` to `dict[str, Any]` — it returns a dict with `data` and `totalData` keys
- Fix `__get_all_devices` return type from `dict[str, Any]` to `list[dict[str, Any]]` and default from `{}` to `[]` — it returns a list of devices

## Context
Confirmed by existing examples:
- `noah_example.py` accesses `plant_list["data"]` and `plant_list["totalData"]` (dict, not list)
- `tlx_example.py` iterates `for device in devices:` directly over `device_list()` result (list, not dict)

## Test plan
- [ ] Verify TLX/MIN examples still work
- [ ] Type checker passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)