### PR TITLE
ci: pin ruff-action to 0.15.16

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -11,3 +11,4 @@ jobs:
       - uses: astral-sh/ruff-action@v3
         with:
           src: "./growattServer"
+          version: "0.15.16"


### PR DESCRIPTION
## Summary
- The Ruff Action (`astral-sh/ruff-action@v3`) has no `version` input, so it always installs whatever is currently "latest."
- `ruff 0.16.0` fails CI on files unrelated to any given PR's diff — it flags `CPY001` (missing copyright notice) and `PLR0917` (too-many-positional-arguments) under this repo's `select = ["ALL"]` config, neither of which the existing codebase (unrelated to any specific PR) satisfies.
- This makes CI fail nondeterministically depending on when a PR happens to trigger a fresh ruff install, not on that PR's actual changes — I hit this on #155 even though it only touches `exceptions.py`/`tests/`.
- Pinning to `0.15.16` — the version used by the last known-green CI run (`f20d445`) — restores a clean, reproducible `ruff check`.

## Test plan
- [x] Ran `ruff==0.15.16 check ./growattServer` locally against current `master` — all checks pass.
- [x] `ruff==0.16.0` (unpinned/"latest") reproduces the CI failure locally, confirming the version bump is the cause, not any code change.