### PR TITLE
Fix plant_id type annotations in OpenApiV1 (int -> str)

### DIFF
--- a/growattServer/base_api.py
+++ b/growattServer/base_api.py
@@ -198,7 +198,7 @@ class GrowattApi:
             allow_redirects=False
         )
 
-        return response.json().get("back", [])
+        return response.json().get("back", {})
 
     def plant_detail(self, plant_id: str, timespan: Timespan, date: datetime.datetime | None = None) -> dict[str, Any]:
         """

--- a/growattServer/open_api_v1/__init__.py
+++ b/growattServer/open_api_v1/__init__.py
@@ -119,12 +119,12 @@ class OpenApiV1(GrowattApi):
 
         return self.process_response(response.json(), "getting plant list")
 
-    def plant_details(self, plant_id: int) -> dict[str, Any]:
+    def plant_details(self, plant_id: str) -> dict[str, Any]:
         """
         Get basic information about a power station.
 
         Args:
-            plant_id (int): Power Station ID
+            plant_id (str): Power Station ID
 
         Returns:
             dict: A dictionary containing the plant details.
@@ -147,12 +147,12 @@ class OpenApiV1(GrowattApi):
 
         return self.process_response(response.json(), "getting plant details")
 
-    def plant_energy_overview(self, plant_id: int) -> dict[str, Any]:
+    def plant_energy_overview(self, plant_id: str) -> dict[str, Any]:
         """
         Get an overview of a plant's energy data.
 
         Args:
-            plant_id (int): Power Station ID
+            plant_id (str): Power Station ID
 
         Returns:
             dict: A dictionary containing the plant energy overview.
@@ -175,7 +175,7 @@ class OpenApiV1(GrowattApi):
         return self.process_response(response.json(), "getting plant energy overview")
 
     def plant_power_overview(
-        self, plant_id: int, day: str | date | None = None
+        self, plant_id: str, day: str | date | None = None
     ) -> dict:
         """
         Obtain power data of a certain power station.
@@ -183,7 +183,7 @@ class OpenApiV1(GrowattApi):
         Get the frequency once every 5 minutes
 
         Args:
-            plant_id (int): Power Station ID
+            plant_id (str): Power Station ID
             day (date): Date - defaults to today in the local system timezone
 
         Returns:
@@ -224,7 +224,7 @@ class OpenApiV1(GrowattApi):
 
     def plant_energy_history(
         self,
-        plant_id: int,
+        plant_id: str,
         start_date: date | None = None,
         end_date: date | None = None,
         time_unit: str = "day",
@@ -235,7 +235,7 @@ class OpenApiV1(GrowattApi):
         Retrieve plant energy data for multiple days/months/years.
 
         Args:
-            plant_id (int): Power Station ID
+            plant_id (str): Power Station ID
             start_date (date, optional): Start Date - defaults to today in the local system timezone
             end_date (date, optional): End Date - defaults to today in the local system timezone
             time_unit (str, optional): Time unit ('day', 'month', 'year') - defaults to 'day'
@@ -308,7 +308,7 @@ class OpenApiV1(GrowattApi):
 
         return self.process_response(response.json(), "getting plant energy history")
 
-    def device_list(self, plant_id: int) -> dict[str, Any]:  # type: ignore[override]
+    def device_list(self, plant_id: str) -> dict[str, Any]:  # type: ignore[override]
         """
         Get devices associated with plant.
 
@@ -326,7 +326,7 @@ class OpenApiV1(GrowattApi):
             10: pbd
 
         Args:
-            plant_id (int): Power Station ID
+            plant_id (str): Power Station ID
 
         Returns:
             DeviceList


### PR DESCRIPTION
Follow-up to the `py.typed` typing added in 2.2.0. A few annotations didn't match the actual runtime shapes / call sites, forcing downstream consumers (Home Assistant) into `# type: ignore` and `Any`. Fixing them at the source.

Fixes #157.

### Changes

1. **`OpenApiV1` `plant_id: int` → `str`** (all five methods: `plant_details`, `plant_energy_overview`, `plant_power_overview`, `plant_energy_history`, `device_list`, plus docstrings). Plant IDs are opaque string identifiers — this matches `GrowattApi`'s own signatures and how callers pass them. The `int` annotations made mypy reject the (correct) `str` arguments in consumers.

2. **`GrowattApi.plant_list` fallback default `[]` → `{}`.** The return type is already annotated `dict[str, Any]` on `master`, but the fallback still returned a `list` when the `back` key is absent. `{}` matches the declared type and the real shape (`{"data": [...], "totalData": {...}}`).

### Notes

- `OpenApiV1.device_list` keeps its `# type: ignore[override]`: it still returns `dict` while the base `GrowattApi.device_list` returns `list`, so it remains an intentional LSP divergence (two different APIs). The `int`→`str` change only aligns the parameter.
- The `plant_list` **return type** and docstring were already corrected to `dict` on `master`, so they're not part of this diff — only the fallback default remained.

### Verification

- `mypy --ignore-missing-imports growattServer/` — clean.
- `ruff check growattServer/` — clean.
