### PR TITLE
Fix incorrect type annotations in OpenApiV1 plant_id and plant_list

### DIFF
--- a/growattServer/base_api.py
+++ b/growattServer/base_api.py
@@ -198,7 +198,7 @@ class GrowattApi:
             allow_redirects=False
         )
 
-        return response.json().get("back", [])
+        return response.json().get("back", {})
 
     def plant_detail(self, plant_id: str, timespan: Timespan, date: datetime.datetime | None = None) -> dict[str, Any]:
         """

--- a/growattServer/open_api_v1/__init__.py
+++ b/growattServer/open_api_v1/__init__.py
@@ -119,12 +119,12 @@ class OpenApiV1(GrowattApi):
 
         return self.process_response(response.json(), "getting plant list")
 
-    def plant_details(self, plant_id: int) -> dict[str, Any]:
+    def plant_details(self, plant_id: str) -> dict[str, Any]:
         """
         Get basic information about a power station.
 
         Args:
-            plant_id (int): Power Station ID
+            plant_id (str): Power Station ID
 
         Returns:
             dict: A dictionary containing the plant details.
@@ -147,12 +147,12 @@ class OpenApiV1(GrowattApi):
 
         return self.process_response(response.json(), "getting plant details")
 
-    def plant_energy_overview(self, plant_id: int) -> dict[str, Any]:
+    def plant_energy_overview(self, plant_id: str) -> dict[str, Any]:
         """
         Get an overview of a plant's energy data.
 
         Args:
-            plant_id (int): Power Station ID
+            plant_id (str): Power Station ID
 
         Returns:
             dict: A dictionary containing the plant energy overview.
@@ -175,7 +175,7 @@ class OpenApiV1(GrowattApi):
         return self.process_response(response.json(), "getting plant energy overview")
 
     def plant_power_overview(
-        self, plant_id: int, day: str | date | None = None
+        self, plant_id: str, day: str | date | None = None
     ) -> dict:
         """
         Obtain power data of a certain power station.
@@ -183,7 +183,7 @@ class OpenApiV1(GrowattApi):
         Get the frequency once every 5 minutes
 
         Args:
-            plant_id (int): Power Station ID
+            plant_id (str): Power Station ID
             day (date): Date - defaults to today in the local system timezone
 
         Returns:
@@ -224,7 +224,7 @@ class OpenApiV1(GrowattApi):
 
     def plant_energy_history(
         self,
-        plant_id: int,
+        plant_id: str,
         start_date: date | None = None,
         end_date: date | None = None,
         time_unit: str = "day",
@@ -235,7 +235,7 @@ class OpenApiV1(GrowattApi):
         Retrieve plant energy data for multiple days/months/years.
 
         Args:
-            plant_id (int): Power Station ID
+            plant_id (str): Power Station ID
             start_date (date, optional): Start Date - defaults to today in the local system timezone
             end_date (date, optional): End Date - defaults to today in the local system timezone
             time_unit (str, optional): Time unit ('day', 'month', 'year') - defaults to 'day'
@@ -308,7 +308,7 @@ class OpenApiV1(GrowattApi):
 
         return self.process_response(response.json(), "getting plant energy history")
 
-    def device_list(self, plant_id: int) -> dict[str, Any]:  # type: ignore[override]
+    def device_list(self, plant_id: str) -> dict[str, Any]:  # type: ignore[override]
         """
         Get devices associated with plant.
 
@@ -326,7 +326,7 @@ class OpenApiV1(GrowattApi):
             10: pbd
 
         Args:
-            plant_id (int): Power Station ID
+            plant_id (str): Power Station ID
 
         Returns:
             DeviceList


### PR DESCRIPTION
Closes #157.

## 1. V1 `plant_id` annotations

`GrowattApi` annotates `plant_id` as `str` on every method that takes one, but `OpenApiV1` annotates it as `int` on `plant_details`, `plant_energy_overview`, `plant_power_overview`, `plant_energy_history` and `device_list`.

All five only pass the value through to `params={"plant_id": plant_id}`, so `str` has always worked at runtime — only the annotation disagreed. Since 2.2.0 shipped `py.typed`, the mismatch is now visible to consumers: a caller holding a plant id as a `str` (which is what the base class returns, and what the ID naturally is) must either suppress `arg-type` errors or coerce with `int()` — and coercing crashes on non-numeric ids.

The `# type: ignore[override]` on `device_list` is left in place — it covers the return type differing from the base class (`dict` vs `list`), which is unrelated to `plant_id`.

## 2. `plant_list` empty-case return

#153 corrected the `plant_list` annotation to `dict[str, Any]`, but the fallback when the response has no `back` key is still `[]`:

```python
def plant_list(self, user_id: str) -> dict[str, Any]:
    ...
    return response.json().get("back", [])
```

So the empty case returns a list and contradicts the annotation. A caller that follows the annotation and does `plant_info.get("data")` hits an `AttributeError` on that path, which forces an `isinstance()` guard purely to defend against the default. `plant_detail`, on the same endpoint family, already defaults to `{}`.

## Scope

Both changes are annotation-consistency fixes; the only runtime change is the `{}` default in the empty-response path, which replaces an `AttributeError` with a falsy dict.

## Release note

Together with #153 — merged but unreleased, as 2.2.0 shipped one day before it landed — this unblocks removing the remaining type suppressions and defensive guards in the Home Assistant `growatt_server` integration (home-assistant/core#173220). Verified locally: with this branch installed, that integration's `# type: ignore[arg-type]` comments delete cleanly with mypy passing and its full test suite green. A 2.3.0 covering both PRs would let those changes land.
